### PR TITLE
Added log level parameters to suppress command output

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,9 @@ Within `SshTask` closure, following methods and properties are available:
   * `session(remotes)` - Adds each session of remote hosts. If a list is given, sessions will be executed in order. Otherwise, order is not defined.
   * `config(key: value)` - Adds an configuration entry. All configurations are given to JSch. This method overwrites entries if same defined in convention.
   * `dryRun` - Dry run flag. If true, performs no action. Default is according to the convention property.
-  * `logger` - Default is `project.logger`
+  * `outputLogLevel` - Log level of standard output while command execution. Default is according to the convention property.
+  * `errorLogLevel` - Log level of standard error while command execution. Default is according to the convention property.
+  * `logger` - (deprecated)
 
 Specification of the closure is defined in [class SshSpec](src/main/groovy/org/hidetake/gradle/ssh/api/SshSpec.groovy).
 Note that the closure will be called in **evaluation** phase on Gradle.
@@ -162,7 +164,9 @@ Following properties and methods are available:
   * `dryRun` - Dry run flag. If true, performs no action. Default is false.
   * `retryCount` - Retrying count to establish connection. Default is 0 (no retry).
   * `retryWaitSec` - Time in seconds between each retries. Default is 0 (immediately).
-  * `logger` - Default is `project.logger`
+  * `outputLogLevel` - Log level of standard output while command execution. Default is QUIET.
+  * `errorLogLevel` - Log level of standard error while command execution. Default is ERROR.
+  * `logger` - (deprecated)
 
 Specification of the closure is defined in [SshSpec](src/main/groovy/org/hidetake/gradle/ssh/api/SshSpec.groovy)
 

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -63,6 +63,8 @@ task showEnvironmentAll(type: SshTask) {
 }
 
 task obtainValue(type: SshTask) {
+    description 'obtaining value from remote command (silent)'
+    outputLogLevel = LogLevel.DEBUG
     session(remotes.localhost) {
         def targetArchitecture = execute('uname -sm').trim()
         println "target architecture is ${targetArchitecture}."

--- a/src/main/groovy/org/hidetake/gradle/ssh/api/SshSpec.groovy
+++ b/src/main/groovy/org/hidetake/gradle/ssh/api/SshSpec.groovy
@@ -1,5 +1,6 @@
 package org.hidetake.gradle.ssh.api
 
+import org.gradle.api.logging.LogLevel
 import org.gradle.api.logging.Logger
 
 /**
@@ -29,6 +30,16 @@ class SshSpec {
      * Logger.
      */
     Logger logger = null
+
+    /**
+     * Log level for standard output of commands.
+     */
+    LogLevel outputLogLevel = null
+
+    /**
+     * Log level for standard error of commands.
+     */
+    LogLevel errorLogLevel = null
 
     /**
      * JSch configuration.
@@ -95,6 +106,8 @@ class SshSpec {
         merged.retryCount = specs.collect { it.retryCount }.findResult(0) { it }
         merged.retryWaitSec = specs.collect { it.retryWaitSec }.findResult(0) { it }
         merged.logger = specs.collect { it.logger }.find()
+        merged.outputLogLevel = specs.collect { it.outputLogLevel }.findResult(LogLevel.QUIET) { it }
+        merged.errorLogLevel = specs.collect { it.errorLogLevel }.findResult(LogLevel.ERROR) { it }
         merged
     }
 }

--- a/src/main/groovy/org/hidetake/gradle/ssh/internal/DefaultSshService.groovy
+++ b/src/main/groovy/org/hidetake/gradle/ssh/internal/DefaultSshService.groovy
@@ -65,12 +65,12 @@ class DefaultSshService implements SshService {
             try {
                 def operationEventLogger = new OperationEventLogger(sshSpec.logger, LogLevel.INFO)
                 def exitStatusValidator = new ExitStatusValidator()
-                sessions.each { spec, session ->
-                    def handler = new DefaultOperationHandler(spec, session)
+                sessions.each { sessionSpec, session ->
+                    def handler = new DefaultOperationHandler(sshSpec, sessionSpec, session)
                     handler.listeners.add(channelsLifecycleManager)
                     handler.listeners.add(operationEventLogger)
                     handler.listeners.add(exitStatusValidator)
-                    handler.with(spec.operationClosure)
+                    handler.with(sessionSpec.operationClosure)
                 }
                 channelsLifecycleManager.waitForPending(exitStatusValidator)
             } finally {

--- a/src/main/groovy/org/hidetake/gradle/ssh/internal/LoggingOutputStream.groovy
+++ b/src/main/groovy/org/hidetake/gradle/ssh/internal/LoggingOutputStream.groovy
@@ -1,0 +1,66 @@
+package org.hidetake.gradle.ssh.internal
+
+import groovy.transform.TupleConstructor
+import org.gradle.api.logging.LogLevel
+import org.gradle.api.logging.Logger
+
+/**
+ * An implementation of {@link OutputStream} with logging facility.
+ *
+ * @author hidetake.org
+ */
+@TupleConstructor
+class LoggingOutputStream extends OutputStream {
+    final Logger logger
+    final LogLevel logLevel
+
+    private static final LINE_SEPARATOR = ~/\r\n|[\n\r\u2028\u2029\u0085]/
+    private final buffer = new ByteArrayOutputStream(512)
+    private lastBlock = ''
+
+    /**
+     * Line string filter.
+     * Default is pass-through.
+     */
+    Closure<Boolean> filter = { String line -> true }
+
+    /**
+     * List of output lines.
+     * Access this property after {@link #close()} in order to ensure last block is committed.
+     */
+    final List<String> lines = []
+
+    void write(int b) {
+        buffer.write(b)
+    }
+
+    /**
+     * Flushes buffer.
+     * Because it may be called regardless of line separators,
+     * it should save last block and write it with next line.
+     */
+    void flush() {
+        def block = lastBlock + new String(buffer.toByteArray())
+        buffer.reset()
+
+        def blockLines = LINE_SEPARATOR.split(block, Integer.MIN_VALUE).toList()
+        if (!blockLines.empty) {
+            lastBlock = blockLines.pop()
+            blockLines.findAll(filter).each { writeLine it }
+        }
+    }
+
+    void close() {
+        flush()
+        if (!lastBlock.empty && filter(lastBlock)) {
+            writeLine lastBlock
+        }
+    }
+
+    protected void writeLine(String line) {
+        if (logger.isEnabled(logLevel)) {
+            logger.log(logLevel, line)
+        }
+        lines << line
+    }
+}

--- a/src/test/groovy/org/hidetake/gradle/ssh/SshPluginConventionSpec.groovy
+++ b/src/test/groovy/org/hidetake/gradle/ssh/SshPluginConventionSpec.groovy
@@ -1,6 +1,7 @@
 package org.hidetake.gradle.ssh
 
 import org.gradle.api.Project
+import org.gradle.api.logging.LogLevel
 import org.gradle.api.logging.Logger
 import org.gradle.testfixtures.ProjectBuilder
 import org.hidetake.gradle.ssh.api.SshService
@@ -31,7 +32,8 @@ class SshPluginConventionSpec extends Specification {
             retryWaitSec = 1
             logger = [:] as Logger
             config(myConfig: 'myConfigValue')
-
+            outputLogLevel = LogLevel.DEBUG
+            errorLogLevel = LogLevel.INFO
         }
 
         when:
@@ -43,6 +45,8 @@ class SshPluginConventionSpec extends Specification {
             retryCount == 1
             retryWaitSec == 1
             config.myConfig == 'myConfigValue'
+            outputLogLevel == LogLevel.DEBUG
+            errorLogLevel == LogLevel.INFO
         }
     }
 

--- a/src/test/groovy/org/hidetake/gradle/ssh/internal/LoggingOutputStreamSpec.groovy
+++ b/src/test/groovy/org/hidetake/gradle/ssh/internal/LoggingOutputStreamSpec.groovy
@@ -1,0 +1,199 @@
+package org.hidetake.gradle.ssh.internal
+
+import org.gradle.api.logging.LogLevel
+import org.gradle.api.logging.Logger
+import spock.lang.Specification
+
+class LoggingOutputStreamSpec extends Specification {
+
+    def "constructor args"() {
+        given:
+        def logger = createLoggerMock(LogLevel.QUIET)
+
+        when:
+        def stream = new LoggingOutputStream(logger, LogLevel.QUIET)
+
+        then:
+        stream.logger == logger
+        stream.logLevel == LogLevel.QUIET
+    }
+
+    def "logging disabled"() {
+        given:
+        def logger = Mock(Logger)
+        def stream = new LoggingOutputStream(logger, LogLevel.ERROR)
+
+        logger.isEnabled(LogLevel.INFO) >> true
+
+        when:
+        stream.write(0x23)
+        stream.close()
+
+        then:
+        0 * logger.log(_, _)
+    }
+
+    def "a byte"() {
+        given:
+        def logger = createLoggerMock(LogLevel.QUIET)
+        def stream = new LoggingOutputStream(logger, LogLevel.QUIET)
+
+        when:
+        stream.write(0x23)
+        stream.close()
+
+        then:
+        1 * logger.log(LogLevel.QUIET, '#')
+        stream.lines == ['#']
+    }
+
+    def "a line"() {
+        given:
+        def logger = createLoggerMock(LogLevel.QUIET)
+        def stream = new LoggingOutputStream(logger, LogLevel.QUIET)
+
+        when:
+        stream.write('single line'.bytes)
+        stream.close()
+
+        then:
+        1 * logger.log(LogLevel.QUIET, 'single line')
+        stream.lines == ['single line']
+    }
+
+    def "a line terminated with a line separator"() {
+        given:
+        def logger = createLoggerMock(LogLevel.QUIET)
+        def stream = new LoggingOutputStream(logger, LogLevel.QUIET)
+
+        when:
+        stream.write('single line\n'.bytes)
+        stream.close()
+
+        then:
+        1 * logger.log(LogLevel.QUIET, 'single line')
+        stream.lines == ['single line']
+    }
+
+    def "a line terminated with 2 line separators"() {
+        given:
+        def logger = createLoggerMock(LogLevel.QUIET)
+        def stream = new LoggingOutputStream(logger, LogLevel.QUIET)
+
+        when:
+        stream.write('single line\n\n'.bytes)
+        stream.close()
+
+        then:
+        1 * logger.log(LogLevel.QUIET, 'single line')
+        1 * logger.log(LogLevel.QUIET, '')
+        stream.lines == ['single line', '']
+    }
+
+    def "blank lines"() {
+        given:
+        def logger = createLoggerMock(LogLevel.QUIET)
+        def stream = new LoggingOutputStream(logger, LogLevel.QUIET)
+
+        when:
+        stream.write('line1\n\nline2\n\n\n'.bytes)
+        stream.close()
+
+        then:
+        1 * logger.log(LogLevel.QUIET, 'line1')
+        1 * logger.log(LogLevel.QUIET, 'line2')
+        3 * logger.log(LogLevel.QUIET, '')
+        stream.lines == ['line1', '', 'line2', '', '']
+    }
+
+    def "multi-platforms"() {
+        given:
+        def logger = createLoggerMock(LogLevel.QUIET)
+        def stream = new LoggingOutputStream(logger, LogLevel.QUIET)
+
+        when:
+        stream.write('line1\r\n\rline2\u2028line3\n\u2029line4\u0085line5'.bytes)
+        stream.close()
+
+        then:
+        1 * logger.log(LogLevel.QUIET, 'line1')
+        1 * logger.log(LogLevel.QUIET, 'line2')
+        1 * logger.log(LogLevel.QUIET, 'line3')
+        1 * logger.log(LogLevel.QUIET, 'line4')
+        1 * logger.log(LogLevel.QUIET, 'line5')
+        2 * logger.log(LogLevel.QUIET, '')
+        stream.lines == ['line1', '', 'line2', 'line3', '', 'line4', 'line5']
+    }
+
+    def "flush on each lines"() {
+        given:
+        def logger = createLoggerMock(LogLevel.QUIET)
+        def stream = new LoggingOutputStream(logger, LogLevel.QUIET)
+
+        when:
+        stream.with {
+            write('line1\n'.bytes)
+            flush()
+            write('line2\n'.bytes)
+            close()
+        }
+
+        then:
+        1 * logger.log(LogLevel.QUIET, 'line1')
+        1 * logger.log(LogLevel.QUIET, 'line2')
+        stream.lines == ['line1', 'line2']
+    }
+
+    def "flush before line separator"() {
+        given:
+        def logger = createLoggerMock(LogLevel.QUIET)
+        def stream = new LoggingOutputStream(logger, LogLevel.QUIET)
+
+        when:
+        stream.with {
+            write('lin'.bytes)
+            flush()
+            write('e3\n'.bytes)
+            flush()
+            write('li'.bytes)
+            flush()
+            write('ne4'.bytes)
+            close()
+        }
+
+        then:
+        1 * logger.log(LogLevel.QUIET, 'line3')
+        1 * logger.log(LogLevel.QUIET, 'line4')
+        stream.lines == ['line3', 'line4']
+    }
+
+    def "apply filter"() {
+        given:
+        def logger = createLoggerMock(LogLevel.QUIET)
+        def stream = new LoggingOutputStream(logger, LogLevel.QUIET)
+        stream.filter = { String line -> line.contains('4') }
+
+        when:
+        stream.with {
+            write('lin'.bytes)
+            flush()
+            write('e3\n'.bytes)
+            flush()
+            write('li'.bytes)
+            flush()
+            write('ne4'.bytes)
+            close()
+        }
+
+        then:
+        1 * logger.log(LogLevel.QUIET, 'line4')
+        stream.lines == ['line4']
+    }
+
+    protected createLoggerMock(LogLevel level) {
+        def logger = Mock(Logger)
+        logger.isEnabled(level) >> true
+        logger
+    }
+
+}

--- a/src/test/groovy/org/hidetake/gradle/ssh/internal/SshSpecSpec.groovy
+++ b/src/test/groovy/org/hidetake/gradle/ssh/internal/SshSpecSpec.groovy
@@ -1,5 +1,6 @@
 package org.hidetake.gradle.ssh.internal
 
+import org.gradle.api.logging.LogLevel
 import org.gradle.api.logging.Logger
 import org.hidetake.gradle.ssh.api.Remote
 import org.hidetake.gradle.ssh.api.SessionSpec
@@ -133,6 +134,8 @@ class SshSpecSpec extends Specification {
             retryCount = 2
             retryWaitSec = 2
             logger = Mock(Logger)
+            outputLogLevel = LogLevel.DEBUG
+            errorLogLevel = LogLevel.INFO
             config([myConf: 'myConf2'])
 
             it
@@ -148,8 +151,8 @@ class SshSpecSpec extends Specification {
         merged.retryCount == spec2.retryCount
         merged.retryWaitSec == spec2.retryWaitSec
         merged.logger == spec2.logger
-
-
+        merged.outputLogLevel == spec2.outputLogLevel
+        merged.errorLogLevel == spec2.errorLogLevel
     }
 
     private def assertEquals(SshSpec expected, SshSpec actual) {
@@ -159,6 +162,8 @@ class SshSpecSpec extends Specification {
         assert expected.retryWaitSec == actual.retryWaitSec
         assert expected.sessionSpecs == actual.sessionSpecs
         assert expected.logger == actual.logger
+        assert expected.outputLogLevel == actual.outputLogLevel
+        assert expected.errorLogLevel == actual.errorLogLevel
 
         true
     }

--- a/src/test/groovy/org/hidetake/gradle/ssh/test/TestDataHelper.groovy
+++ b/src/test/groovy/org/hidetake/gradle/ssh/test/TestDataHelper.groovy
@@ -1,5 +1,6 @@
 package org.hidetake.gradle.ssh.test
 
+import org.gradle.api.logging.LogLevel
 import org.gradle.api.logging.Logger
 import org.hidetake.gradle.ssh.api.Remote
 import org.hidetake.gradle.ssh.api.SessionSpec
@@ -14,6 +15,8 @@ class TestDataHelper {
             retryWaitSec = 1
             logger = [:] as Logger
             config([myConf: 'myConf'])
+            outputLogLevel = LogLevel.LIFECYCLE
+            errorLogLevel = LogLevel.LIFECYCLE
 
             it
         }


### PR DESCRIPTION
Added parameters to control output of command execution.

Changed to use Gradle logger instead of `System.out` for command output.
In future it can easily customise command output, e.g. prepending host name.
