### PR TITLE
Adds charset encoding support for command execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,8 +104,9 @@ In the `SshTask` closure, following methods and properties are available:
   * `session(remotes)` - Adds each session of remote hosts. If a list is given, sessions will be executed in order. Otherwise, order is not defined.
   * `config(key: value)` - Adds an configuration entry. All configurations are given to JSch. This method overwrites entries if same defined in convention.
   * `dryRun` - Dry run flag. If true, performs no action. Default is according to the convention property.
-  * `outputLogLevel` - Log level of standard output while command execution. Default is according to the convention property.
-  * `errorLogLevel` - Log level of standard error while command execution. Default is according to the convention property.
+  * `outputLogLevel` - Log level of standard output for executing commands. Default is according to the convention property.
+  * `errorLogLevel` - Log level of standard error for executing commands. Default is according to the convention property.
+  * `encoding` - Encoding of input and output for executing commands. Default is UTF-8.
   * `logger` - (deprecated)
 
 Specification of the closure is defined in the [class SshSpec](src/main/groovy/org/hidetake/gradle/ssh/api/SshSpec.groovy).

--- a/src/main/groovy/org/hidetake/gradle/ssh/api/SshSpec.groovy
+++ b/src/main/groovy/org/hidetake/gradle/ssh/api/SshSpec.groovy
@@ -42,6 +42,11 @@ class SshSpec {
     LogLevel errorLogLevel = null
 
     /**
+     * Encoding of input and output stream.
+     */
+    String encoding = null
+
+    /**
      * JSch configuration.
      */
     final config = [:] as Map<String, Object>
@@ -108,6 +113,7 @@ class SshSpec {
         merged.logger = specs.collect { it.logger }.find()
         merged.outputLogLevel = specs.collect { it.outputLogLevel }.findResult(LogLevel.QUIET) { it }
         merged.errorLogLevel = specs.collect { it.errorLogLevel }.findResult(LogLevel.ERROR) { it }
+        merged.encoding = specs.collect { it.encoding }.findResult('UTF-8') { it }
         merged
     }
 }

--- a/src/main/groovy/org/hidetake/gradle/ssh/internal/DefaultOperationHandler.groovy
+++ b/src/main/groovy/org/hidetake/gradle/ssh/internal/DefaultOperationHandler.groovy
@@ -39,8 +39,8 @@ class DefaultOperationHandler implements OperationHandler {
         channel.command = command
         options.each { k, v -> channel[k] = v }
 
-        def outputLogger = new LoggingOutputStream(sshSpec.logger, sshSpec.outputLogLevel)
-        def errorLogger = new LoggingOutputStream(sshSpec.logger, sshSpec.errorLogLevel)
+        def outputLogger = new LoggingOutputStream(sshSpec.logger, sshSpec.outputLogLevel, sshSpec.encoding)
+        def errorLogger = new LoggingOutputStream(sshSpec.logger, sshSpec.errorLogLevel, sshSpec.encoding)
         channel.outputStream = outputLogger
         channel.errStream = errorLogger
 
@@ -73,8 +73,8 @@ class DefaultOperationHandler implements OperationHandler {
         channel.command = "sudo -S -p '' $command"
         options.each { k, v -> channel[k] = v }
 
-        def outputLogger = new LoggingOutputStream(sshSpec.logger, sshSpec.outputLogLevel)
-        def errorLogger = new LoggingOutputStream(sshSpec.logger, sshSpec.errorLogLevel)
+        def outputLogger = new LoggingOutputStream(sshSpec.logger, sshSpec.outputLogLevel, sshSpec.encoding)
+        def errorLogger = new LoggingOutputStream(sshSpec.logger, sshSpec.errorLogLevel, sshSpec.encoding)
         channel.outputStream = outputLogger
         channel.errStream = errorLogger
 
@@ -97,8 +97,8 @@ class DefaultOperationHandler implements OperationHandler {
         try {
             channel.connect()
             listeners*.managedChannelConnected(channel, sessionSpec)
-            channel.outputStream.withWriter {
-                it.write(sessionSpec.remote.password + '\n')
+            channel.outputStream.withWriter(sshSpec.encoding) {
+                it << sessionSpec.remote.password << '\n'
             }
             while (!channel.closed) {
                 if (authenticationFailed) {
@@ -127,8 +127,8 @@ class DefaultOperationHandler implements OperationHandler {
 
         def channel = session.openChannel('exec') as ChannelExec
         channel.command = command
-        channel.outputStream = new LoggingOutputStream(sshSpec.logger, sshSpec.outputLogLevel)
-        channel.errStream = new LoggingOutputStream(sshSpec.logger, sshSpec.errorLogLevel)
+        channel.outputStream = new LoggingOutputStream(sshSpec.logger, sshSpec.outputLogLevel, sshSpec.encoding)
+        channel.errStream = new LoggingOutputStream(sshSpec.logger, sshSpec.errorLogLevel, sshSpec.encoding)
         options.each { k, v -> channel[k] = v }
 
         channel.connect()

--- a/src/main/groovy/org/hidetake/gradle/ssh/internal/LoggingOutputStream.groovy
+++ b/src/main/groovy/org/hidetake/gradle/ssh/internal/LoggingOutputStream.groovy
@@ -13,6 +13,7 @@ import org.gradle.api.logging.Logger
 class LoggingOutputStream extends OutputStream {
     final Logger logger
     final LogLevel logLevel
+    final String charset = 'UTF-8'
 
     private static final LINE_SEPARATOR = ~/\r\n|[\n\r\u2028\u2029\u0085]/
     private final buffer = new ByteArrayOutputStream(512)
@@ -40,7 +41,7 @@ class LoggingOutputStream extends OutputStream {
      * it should save last block and write it with next line.
      */
     void flush() {
-        def block = lastBlock + new String(buffer.toByteArray())
+        def block = lastBlock + new String(buffer.toByteArray(), charset)
         buffer.reset()
 
         def blockLines = LINE_SEPARATOR.split(block, Integer.MIN_VALUE).toList()

--- a/src/test/groovy/org/hidetake/gradle/ssh/internal/LoggingOutputStreamSpec.groovy
+++ b/src/test/groovy/org/hidetake/gradle/ssh/internal/LoggingOutputStreamSpec.groovy
@@ -18,7 +18,7 @@ class LoggingOutputStreamSpec extends Specification {
     }
 
 
-    def "a byte"() {
+    def "write a byte"() {
         when:
         stream.write(0x23)
         stream.close()
@@ -28,10 +28,36 @@ class LoggingOutputStreamSpec extends Specification {
         stream.lines == ['#']
     }
 
-    def "a line"() {
+    def "write bytes"() {
         when:
-        stream.write('single line'.bytes)
+        stream << utf8bytes('line3\nline4\nline5')
         stream.close()
+
+        then:
+        1 * logger.log(LogLevel.QUIET, 'line3')
+        1 * logger.log(LogLevel.QUIET, 'line4')
+        1 * logger.log(LogLevel.QUIET, 'line5')
+        stream.lines == ['line3', 'line4', 'line5']
+    }
+
+    def "write lines with writer"() {
+        when:
+        stream.withWriter('UTF-8') {
+            it << 'line3\nline4\nline5'
+        }
+
+        then:
+        1 * logger.log(LogLevel.QUIET, 'line3')
+        1 * logger.log(LogLevel.QUIET, 'line4')
+        1 * logger.log(LogLevel.QUIET, 'line5')
+        stream.lines == ['line3', 'line4', 'line5']
+    }
+
+    def "a line without line separator"() {
+        when:
+        stream.withWriter('UTF-8') {
+            it << 'single line'
+        }
 
         then:
         1 * logger.log(LogLevel.QUIET, 'single line')
@@ -40,8 +66,9 @@ class LoggingOutputStreamSpec extends Specification {
 
     def "a line terminated with a line separator"() {
         when:
-        stream.write('single line\n'.bytes)
-        stream.close()
+        stream.withWriter('UTF-8') {
+            it << 'single line\n'
+        }
 
         then:
         // a terminated line separator should be ignored
@@ -52,8 +79,9 @@ class LoggingOutputStreamSpec extends Specification {
     @Unroll
     def "a line terminated with #n line separators"() {
         when:
-        stream.write("single line${'\n' * n}".toString().bytes)
-        stream.close()
+        stream.withWriter('UTF-8') {
+            it << "single line${'\n' * n}"
+        }
 
         then:
         1 * logger.log(LogLevel.QUIET, 'single line')
@@ -68,8 +96,9 @@ class LoggingOutputStreamSpec extends Specification {
     @Unroll
     def "a line starting with #n line separators"() {
         when:
-        stream.write("${'\n' * n}single line".toString().bytes)
-        stream.close()
+        stream.withWriter('UTF-8') {
+            it << "${'\n' * n}single line"
+        }
 
         then:
         1 * logger.log(LogLevel.QUIET, 'single line')
@@ -85,8 +114,9 @@ class LoggingOutputStreamSpec extends Specification {
     @Unroll
     def "a line with #n line separators in the middle"() {
         when:
-        stream.write("line1${'\n' * n}line2".toString().bytes)
-        stream.close()
+        stream.withWriter('UTF-8') {
+            it << "line1${'\n' * n}line2"
+        }
 
         then:
         1 * logger.log(LogLevel.QUIET, 'line1')
@@ -103,8 +133,9 @@ class LoggingOutputStreamSpec extends Specification {
 
     def "multi-platforms"() {
         when:
-        stream.write('line1\r\n\rline2\u2028line3\n\u2029line4\u0085line5'.bytes)
-        stream.close()
+        stream.withWriter('UTF-8') {
+            it << 'line1\r\n\rline2\u2028line3\n\u2029line4\u0085line5'
+        }
 
         then:
         1 * logger.log(LogLevel.QUIET, 'line1')
@@ -120,19 +151,19 @@ class LoggingOutputStreamSpec extends Specification {
     def "flush in line #n times"() {
         when:
         stream.with {
-            write('lin'.bytes)
+            write(utf8bytes('lin'))
             (1..n).each {
                 flush()
             }
-            write('e3\n'.bytes)
+            write(utf8bytes('e3\n'))
             (1..n).each {
                 flush()
             }
-            write('li'.bytes)
+            write(utf8bytes('li'))
             (1..n).each {
                 flush()
             }
-            write('ne4'.bytes)
+            write(utf8bytes('ne4'))
             close()
         }
 
@@ -148,7 +179,7 @@ class LoggingOutputStreamSpec extends Specification {
     @Unroll
     def "close #n times, a line"() {
         when:
-        stream.write('single line'.bytes)
+        stream.write(utf8bytes('single line'))
         (1..n).each {
             stream.close()
         }
@@ -164,7 +195,7 @@ class LoggingOutputStreamSpec extends Specification {
     @Unroll
     def "close #n times, a line terminated with a line separator"() {
         when:
-        stream.write('single line\n'.bytes)
+        stream.write(utf8bytes('single line\n'))
         (1..n).each {
             stream.close()
         }
@@ -178,32 +209,19 @@ class LoggingOutputStreamSpec extends Specification {
         n << (1..3)
     }
 
-    def "with writer"() {
-        when:
-        stream.withWriter {
-            it.append 'line3\nline4\nline5'
-        }
-
-        then:
-        1 * logger.log(LogLevel.QUIET, 'line3')
-        1 * logger.log(LogLevel.QUIET, 'line4')
-        1 * logger.log(LogLevel.QUIET, 'line5')
-        stream.lines == ['line3', 'line4', 'line5']
-    }
-
     def "apply filter"() {
         given:
         stream.filter = { String line -> line.contains('4') }
 
         when:
         stream.with {
-            write('lin'.bytes)
+            write(utf8bytes('lin'))
             flush()
-            write('e3\n'.bytes)
+            write(utf8bytes('e3\n'))
             flush()
-            write('li'.bytes)
+            write(utf8bytes('li'))
             flush()
-            write('ne4'.bytes)
+            write(utf8bytes('ne4'))
             close()
         }
 
@@ -211,6 +229,7 @@ class LoggingOutputStreamSpec extends Specification {
         1 * logger.log(LogLevel.QUIET, 'line4')
         stream.lines == ['line4']
     }
+
 
     def "logging disabled"() {
         given:
@@ -225,6 +244,25 @@ class LoggingOutputStreamSpec extends Specification {
 
         then:
         0 * logger.log(_, _ as String)
+    }
+
+
+    def "explicit charset"() {
+        given:
+        stream = new LoggingOutputStream(logger, LogLevel.QUIET, 'Shift_JIS')
+
+        when:
+        stream.withWriter('Shift_JIS') {
+            it << 'これは\n日本語です'
+        }
+
+        then:
+        stream.lines == ['これは', '日本語です']
+    }
+
+
+    static utf8bytes(String s) {
+        s.getBytes('UTF-8')
     }
 
 }

--- a/src/test/groovy/org/hidetake/gradle/ssh/internal/SshSpecSpec.groovy
+++ b/src/test/groovy/org/hidetake/gradle/ssh/internal/SshSpecSpec.groovy
@@ -11,7 +11,6 @@ import spock.lang.Unroll
 import static org.hidetake.gradle.ssh.test.TestDataHelper.createRemote
 import static org.hidetake.gradle.ssh.test.TestDataHelper.createSpec
 
-
 class SshSpecSpec extends Specification {
 
 
@@ -136,6 +135,7 @@ class SshSpecSpec extends Specification {
             logger = Mock(Logger)
             outputLogLevel = LogLevel.DEBUG
             errorLogLevel = LogLevel.INFO
+            encoding = 'US-ASCII'
             config([myConf: 'myConf2'])
 
             it
@@ -153,6 +153,7 @@ class SshSpecSpec extends Specification {
         merged.logger == spec2.logger
         merged.outputLogLevel == spec2.outputLogLevel
         merged.errorLogLevel == spec2.errorLogLevel
+        merged.encoding == spec2.encoding
     }
 
     private def assertEquals(SshSpec expected, SshSpec actual) {


### PR DESCRIPTION
Adds possibility to set character encoding for remote command execution. This may fix garbled characters due to difference of locale between server-side (LANG or LC_ALL) and client-side (file.encoding).
