### PR TITLE
Use each class loggers instead of project logger

### DIFF
--- a/src/main/groovy/org/hidetake/gradle/ssh/SshPlugin.groovy
+++ b/src/main/groovy/org/hidetake/gradle/ssh/SshPlugin.groovy
@@ -18,7 +18,7 @@ class SshPlugin implements Plugin<Project> {
     @Override
     void apply(Project project) {
         attachRemoteContainer(project)
-        project.convention.plugins.put('ssh', new SshPluginConvention(project))
+        project.convention.plugins.put('ssh', new SshPluginConvention())
     }
 
     protected attachRemoteContainer(Project project) {

--- a/src/main/groovy/org/hidetake/gradle/ssh/SshPluginConvention.groovy
+++ b/src/main/groovy/org/hidetake/gradle/ssh/SshPluginConvention.groovy
@@ -1,6 +1,5 @@
 package org.hidetake.gradle.ssh
 
-import org.gradle.api.Project
 import org.gradle.util.ConfigureUtil
 import org.hidetake.gradle.ssh.api.SshSpec
 import org.hidetake.gradle.ssh.internal.DefaultSshService
@@ -25,10 +24,6 @@ class SshPluginConvention {
     // fixes inspection warning (Unnecessary fully qualified name)
     private static final classOfSshTask = SshTask
 
-    SshPluginConvention(Project project) {
-        sshSpec.logger = project.logger
-    }
-
     /**
      * Configures global settings.
      *
@@ -40,9 +35,6 @@ class SshPluginConvention {
         ConfigureUtil.configure(configureClosure, sshSpec)
         if (sshSpec.sessionSpecs.size() > 0) {
             throw new IllegalStateException('Do not declare any session in convention')
-        }
-        if (sshSpec.logger == null) {
-            throw new IllegalStateException('Do not set logger to null in convention')
         }
     }
 

--- a/src/main/groovy/org/hidetake/gradle/ssh/api/SshSpec.groovy
+++ b/src/main/groovy/org/hidetake/gradle/ssh/api/SshSpec.groovy
@@ -1,7 +1,6 @@
 package org.hidetake.gradle.ssh.api
 
 import org.gradle.api.logging.LogLevel
-import org.gradle.api.logging.Logger
 
 /**
  * Specification of a SSH task.
@@ -25,11 +24,6 @@ class SshSpec {
      * Interval time in seconds between retries.
      */
     Integer retryWaitSec = null
-
-    /**
-     * Logger.
-     */
-    Logger logger = null
 
     /**
      * Log level for standard output of commands.
@@ -110,7 +104,6 @@ class SshSpec {
         merged.dryRun = specs.collect { it.dryRun }.findResult(false) { it }
         merged.retryCount = specs.collect { it.retryCount }.findResult(0) { it }
         merged.retryWaitSec = specs.collect { it.retryWaitSec }.findResult(0) { it }
-        merged.logger = specs.collect { it.logger }.find()
         merged.outputLogLevel = specs.collect { it.outputLogLevel }.findResult(LogLevel.QUIET) { it }
         merged.errorLogLevel = specs.collect { it.errorLogLevel }.findResult(LogLevel.ERROR) { it }
         merged.encoding = specs.collect { it.encoding }.findResult('UTF-8') { it }

--- a/src/main/groovy/org/hidetake/gradle/ssh/internal/DefaultOperationHandler.groovy
+++ b/src/main/groovy/org/hidetake/gradle/ssh/internal/DefaultOperationHandler.groovy
@@ -39,8 +39,8 @@ class DefaultOperationHandler implements OperationHandler {
         channel.command = command
         options.each { k, v -> channel[k] = v }
 
-        def outputLogger = new LoggingOutputStream(sshSpec.logger, sshSpec.outputLogLevel, sshSpec.encoding)
-        def errorLogger = new LoggingOutputStream(sshSpec.logger, sshSpec.errorLogLevel, sshSpec.encoding)
+        def outputLogger = new LoggingOutputStream(sshSpec.outputLogLevel, sshSpec.encoding)
+        def errorLogger = new LoggingOutputStream(sshSpec.errorLogLevel, sshSpec.encoding)
         channel.outputStream = outputLogger
         channel.errStream = errorLogger
 
@@ -73,8 +73,8 @@ class DefaultOperationHandler implements OperationHandler {
         channel.command = "sudo -S -p '' $command"
         options.each { k, v -> channel[k] = v }
 
-        def outputLogger = new LoggingOutputStream(sshSpec.logger, sshSpec.outputLogLevel, sshSpec.encoding)
-        def errorLogger = new LoggingOutputStream(sshSpec.logger, sshSpec.errorLogLevel, sshSpec.encoding)
+        def outputLogger = new LoggingOutputStream(sshSpec.outputLogLevel, sshSpec.encoding)
+        def errorLogger = new LoggingOutputStream(sshSpec.errorLogLevel, sshSpec.encoding)
         channel.outputStream = outputLogger
         channel.errStream = errorLogger
 
@@ -127,8 +127,8 @@ class DefaultOperationHandler implements OperationHandler {
 
         def channel = session.openChannel('exec') as ChannelExec
         channel.command = command
-        channel.outputStream = new LoggingOutputStream(sshSpec.logger, sshSpec.outputLogLevel, sshSpec.encoding)
-        channel.errStream = new LoggingOutputStream(sshSpec.logger, sshSpec.errorLogLevel, sshSpec.encoding)
+        channel.outputStream = new LoggingOutputStream(sshSpec.outputLogLevel, sshSpec.encoding)
+        channel.errStream = new LoggingOutputStream(sshSpec.errorLogLevel, sshSpec.encoding)
         options.each { k, v -> channel[k] = v }
 
         channel.connect()

--- a/src/main/groovy/org/hidetake/gradle/ssh/internal/DryRunSshService.groovy
+++ b/src/main/groovy/org/hidetake/gradle/ssh/internal/DryRunSshService.groovy
@@ -15,12 +15,10 @@ class DryRunSshService implements SshService {
     @Override
     void execute(SshSpec sshSpec) {
         assert sshSpec.dryRun == Boolean.TRUE, 'dryRun should be true'
-        assert sshSpec.logger != null, 'default logger should be set by convention'
 
-        def operationEventLogger = new OperationEventLogger(sshSpec.logger, LogLevel.WARN)
+        def operationEventLogger = new OperationEventLogger(LogLevel.LIFECYCLE)
         sshSpec.sessionSpecs.each { spec ->
             def handler = new DryRunOperationHandler(spec, [operationEventLogger])
-            println handler
             handler.with(spec.operationClosure)
         }
     }

--- a/src/main/groovy/org/hidetake/gradle/ssh/internal/LoggingOutputStream.groovy
+++ b/src/main/groovy/org/hidetake/gradle/ssh/internal/LoggingOutputStream.groovy
@@ -2,7 +2,7 @@ package org.hidetake.gradle.ssh.internal
 
 import groovy.transform.TupleConstructor
 import org.gradle.api.logging.LogLevel
-import org.gradle.api.logging.Logger
+import org.gradle.api.logging.Logging
 
 /**
  * An implementation of {@link OutputStream} with logging facility.
@@ -11,9 +11,10 @@ import org.gradle.api.logging.Logger
  */
 @TupleConstructor
 class LoggingOutputStream extends OutputStream {
-    final Logger logger
     final LogLevel logLevel
     final String charset = 'UTF-8'
+
+    static final logger = Logging.getLogger(LoggingOutputStream)
 
     private static final LINE_SEPARATOR = ~/\r\n|[\n\r\u2028\u2029\u0085]/
     private final buffer = new ByteArrayOutputStream(512)

--- a/src/main/groovy/org/hidetake/gradle/ssh/internal/OperationEventLogger.groovy
+++ b/src/main/groovy/org/hidetake/gradle/ssh/internal/OperationEventLogger.groovy
@@ -3,7 +3,7 @@ package org.hidetake.gradle.ssh.internal
 import com.jcraft.jsch.Channel
 import groovy.transform.TupleConstructor
 import org.gradle.api.logging.LogLevel
-import org.gradle.api.logging.Logger
+import org.gradle.api.logging.Logging
 import org.hidetake.gradle.ssh.api.OperationEventListener
 import org.hidetake.gradle.ssh.api.SessionSpec
 
@@ -15,8 +15,9 @@ import org.hidetake.gradle.ssh.api.SessionSpec
  */
 @TupleConstructor
 class OperationEventLogger implements OperationEventListener {
-    final Logger logger
     final LogLevel logLevel
+
+    static final logger = Logging.getLogger(OperationEventLogger)
 
     @Override
     void beginOperation(String operation, Object... args) {

--- a/src/test/groovy/org/hidetake/gradle/ssh/SshIntegrationTest.groovy
+++ b/src/test/groovy/org/hidetake/gradle/ssh/SshIntegrationTest.groovy
@@ -1,8 +1,8 @@
 package org.hidetake.gradle.ssh
 
 import org.gradle.api.Project
-import org.gradle.api.logging.Logger
 import org.gradle.testfixtures.ProjectBuilder
+import org.hidetake.gradle.ssh.internal.OperationEventLogger
 import spock.lang.Specification
 
 class SshIntegrationTest extends Specification {
@@ -14,31 +14,36 @@ class SshIntegrationTest extends Specification {
         def task = project.tasks.sshTask
         task.dryRun = true
 
-        def loggerMock = Mock(Logger)
-        task.logger = loggerMock
-        loggerMock.isEnabled(_) >> true
+        def loggerMock = GroovySpy(OperationEventLogger.logger.class, global: true) {
+            isEnabled(_) >> true
+        }
 
         when:
         task.perform()
 
         then:
-        1 * loggerMock.log(_, { it.contains("ls -l") })
+        1 * loggerMock.log(_, { it.contains("ls -l") } as String)
     }
 
     def "dry run task with sshexec"() {
         given:
         def project = createProject()
         def task = project.tasks.sshExecTask
-        def globalSpec = project.convention.plugins.ssh.sshSpec
-        def loggerMock = GroovySpy(globalSpec.logger.class, global: true)
-        globalSpec.dryRun = true
+        project.with {
+            ssh {
+                dryRun = true
+            }
+        }
 
+        def loggerMock = GroovySpy(OperationEventLogger.logger.class, global: true) {
+            isEnabled(_) >> true
+        }
 
         when:
         task.execute()
 
         then:
-        1 * loggerMock.log(_, { it.contains("ls -l") })
+        1 * loggerMock.log(_, { it.contains("ls -l") } as String)
     }
 
 

--- a/src/test/groovy/org/hidetake/gradle/ssh/SshPluginConventionSpec.groovy
+++ b/src/test/groovy/org/hidetake/gradle/ssh/SshPluginConventionSpec.groovy
@@ -2,14 +2,12 @@ package org.hidetake.gradle.ssh
 
 import org.gradle.api.Project
 import org.gradle.api.logging.LogLevel
-import org.gradle.api.logging.Logger
 import org.gradle.testfixtures.ProjectBuilder
 import org.hidetake.gradle.ssh.api.SshService
 import org.hidetake.gradle.ssh.api.SshSpec
 import spock.lang.Specification
 
 import static org.hidetake.gradle.ssh.test.TestDataHelper.createRemote
-
 
 class SshPluginConventionSpec extends Specification {
 
@@ -19,7 +17,7 @@ class SshPluginConventionSpec extends Specification {
 
     def setup() {
         project = ProjectBuilder.builder().build()
-        convention = new SshPluginConvention(project)
+        convention = new SshPluginConvention()
     }
 
 
@@ -30,7 +28,6 @@ class SshPluginConventionSpec extends Specification {
             dryRun = true
             retryCount = 1
             retryWaitSec = 1
-            logger = [:] as Logger
             config(myConfig: 'myConfigValue')
             outputLogLevel = LogLevel.DEBUG
             errorLogLevel = LogLevel.INFO
@@ -50,20 +47,6 @@ class SshPluginConventionSpec extends Specification {
         }
     }
 
-    def "configure ssh default values"() {
-        given:
-        def configClosure = {}
-
-        when:
-        convention.ssh(configClosure)
-
-        then:
-        convention.sshSpec.with {
-            logger == project.logger
-        }
-
-    }
-
     def "configure ssh closure must be seg"() {
         when:
         convention.ssh(null)
@@ -80,14 +63,6 @@ class SshPluginConventionSpec extends Specification {
         then:
         IllegalStateException ex = thrown()
         ex.message.contains("session")
-    }
-
-    def "configure ssh does not allow setting logger to null"() {
-        when:
-        convention.ssh({ logger = null })
-        then:
-        IllegalStateException ex = thrown()
-        ex.message.contains("logger")
     }
 
 

--- a/src/test/groovy/org/hidetake/gradle/ssh/internal/DefaultSshServiceTest.groovy
+++ b/src/test/groovy/org/hidetake/gradle/ssh/internal/DefaultSshServiceTest.groovy
@@ -2,8 +2,6 @@ package org.hidetake.gradle.ssh.internal
 
 import com.jcraft.jsch.JSchException
 import org.junit.Test
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
 
 /**
  * Test cases for {@link DefaultSshService}.
@@ -12,12 +10,10 @@ import org.slf4j.LoggerFactory
  *
  */
 class DefaultSshServiceTest {
-    protected final Logger logger = LoggerFactory.getLogger(DefaultSshServiceTest)
-
     @Test
     void retry_0_success() {
         int called = 0
-        DefaultSshService.instance.retry(0, 0, logger) {
+        DefaultSshService.instance.retry(0, 0) {
             called++
             assert called == 1
         }
@@ -27,7 +23,7 @@ class DefaultSshServiceTest {
     @Test(expected = JSchException)
     void retry_0_exception() {
         int called = 0
-        DefaultSshService.instance.retry(0, 0, logger) {
+        DefaultSshService.instance.retry(0, 0) {
             assert called == 0
             throw new JSchException()
         }
@@ -36,7 +32,7 @@ class DefaultSshServiceTest {
     @Test
     void retry_1_success() {
         int called = 0
-        DefaultSshService.instance.retry(1, 0, logger) {
+        DefaultSshService.instance.retry(1, 0) {
             called++
             assert called == 1
         }
@@ -46,7 +42,7 @@ class DefaultSshServiceTest {
     @Test
     void retry_1_exceptionOnce() {
         int called = 0
-        DefaultSshService.instance.retry(1, 0, logger) {
+        DefaultSshService.instance.retry(1, 0) {
             called++
             if (called == 1) {
                 throw new JSchException('this should be handled by retry() method')
@@ -59,7 +55,7 @@ class DefaultSshServiceTest {
     @Test(expected = JSchException)
     void retry_1_exception2times() {
         int called = 0
-        DefaultSshService.instance.retry(1, 0, logger) {
+        DefaultSshService.instance.retry(1, 0) {
             called++
             assert (1..2).contains(called)
             if (called == 1) {
@@ -74,14 +70,14 @@ class DefaultSshServiceTest {
     @Test
     void retry_2_success() {
         int called = 0
-        DefaultSshService.instance.retry(2, 0, logger) { called++ }
+        DefaultSshService.instance.retry(2, 0) { called++ }
         assert called == 1
     }
 
     @Test
     void retry_2_exceptionOnce() {
         int called = 0
-        DefaultSshService.instance.retry(2, 0, logger) {
+        DefaultSshService.instance.retry(2, 0) {
             called++
             assert (1..2).contains(called)
             if (called == 1) {
@@ -94,7 +90,7 @@ class DefaultSshServiceTest {
     @Test
     void retry_2_exception2times() {
         int called = 0
-        DefaultSshService.instance.retry(2, 0, logger) {
+        DefaultSshService.instance.retry(2, 0) {
             called++
             assert (1..3).contains(called)
             if (called == 1) {
@@ -110,7 +106,7 @@ class DefaultSshServiceTest {
     @Test(expected = JSchException)
     void retry_2_exception3times() {
         int called = 0
-        DefaultSshService.instance.retry(2, 0, logger) {
+        DefaultSshService.instance.retry(2, 0) {
             called++
             assert (1..3).contains(called)
             if (called == 1) {

--- a/src/test/groovy/org/hidetake/gradle/ssh/internal/LoggingOutputStreamSpec.groovy
+++ b/src/test/groovy/org/hidetake/gradle/ssh/internal/LoggingOutputStreamSpec.groovy
@@ -11,10 +11,11 @@ class LoggingOutputStreamSpec extends Specification {
     Logger logger
 
     def setup() {
-        logger = Mock(Logger) {
-            isEnabled(_) >> true
+        logger = GroovySpy(OperationEventLogger.logger.class, global: true) {
+            isEnabled(LogLevel.QUIET) >> true
+            isEnabled(_) >> false
         }
-        stream = new LoggingOutputStream(logger, LogLevel.QUIET)
+        stream = new LoggingOutputStream(LogLevel.QUIET)
     }
 
 
@@ -233,10 +234,7 @@ class LoggingOutputStreamSpec extends Specification {
 
     def "logging disabled"() {
         given:
-        logger = Mock(Logger) {
-            isEnabled(_) >> false
-        }
-        stream = new LoggingOutputStream(logger, LogLevel.QUIET)
+        stream = new LoggingOutputStream(LogLevel.DEBUG)
 
         when:
         stream.write(0x23)
@@ -249,7 +247,7 @@ class LoggingOutputStreamSpec extends Specification {
 
     def "explicit charset"() {
         given:
-        stream = new LoggingOutputStream(logger, LogLevel.QUIET, 'Shift_JIS')
+        stream = new LoggingOutputStream(LogLevel.QUIET, 'Shift_JIS')
 
         when:
         stream.withWriter('Shift_JIS') {

--- a/src/test/groovy/org/hidetake/gradle/ssh/internal/SshSpecSpec.groovy
+++ b/src/test/groovy/org/hidetake/gradle/ssh/internal/SshSpecSpec.groovy
@@ -1,7 +1,6 @@
 package org.hidetake.gradle.ssh.internal
 
 import org.gradle.api.logging.LogLevel
-import org.gradle.api.logging.Logger
 import org.hidetake.gradle.ssh.api.Remote
 import org.hidetake.gradle.ssh.api.SessionSpec
 import org.hidetake.gradle.ssh.api.SshSpec
@@ -132,7 +131,6 @@ class SshSpecSpec extends Specification {
             dryRun = true
             retryCount = 2
             retryWaitSec = 2
-            logger = Mock(Logger)
             outputLogLevel = LogLevel.DEBUG
             errorLogLevel = LogLevel.INFO
             encoding = 'US-ASCII'
@@ -150,7 +148,6 @@ class SshSpecSpec extends Specification {
         merged.dryRun == spec2.dryRun
         merged.retryCount == spec2.retryCount
         merged.retryWaitSec == spec2.retryWaitSec
-        merged.logger == spec2.logger
         merged.outputLogLevel == spec2.outputLogLevel
         merged.errorLogLevel == spec2.errorLogLevel
         merged.encoding == spec2.encoding
@@ -162,7 +159,6 @@ class SshSpecSpec extends Specification {
         assert expected.retryCount == actual.retryCount
         assert expected.retryWaitSec == actual.retryWaitSec
         assert expected.sessionSpecs == actual.sessionSpecs
-        assert expected.logger == actual.logger
         assert expected.outputLogLevel == actual.outputLogLevel
         assert expected.errorLogLevel == actual.errorLogLevel
 

--- a/src/test/groovy/org/hidetake/gradle/ssh/server/CommandExecutionTest.groovy
+++ b/src/test/groovy/org/hidetake/gradle/ssh/server/CommandExecutionTest.groovy
@@ -6,10 +6,10 @@ import org.apache.sshd.server.Environment
 import org.apache.sshd.server.PasswordAuthenticator
 import org.gradle.api.Project
 import org.gradle.api.logging.LogLevel
-import org.gradle.api.logging.Logger
 import org.gradle.api.tasks.TaskExecutionException
 import org.gradle.testfixtures.ProjectBuilder
 import org.hidetake.gradle.ssh.SshTask
+import org.hidetake.gradle.ssh.internal.LoggingOutputStream
 import org.hidetake.gradle.ssh.test.ServerBasedTestHelper
 import org.hidetake.gradle.ssh.test.ServerBasedTestHelper.CommandContext
 import spock.lang.Specification
@@ -142,14 +142,13 @@ class CommandExecutionTest extends Specification {
     @Unroll
     def "logging, #description"() {
         given:
-        def loggerMock = Mock(Logger) {
-            isEnabled(_) >> true
+        def logger = GroovySpy(LoggingOutputStream.logger.class, global: true) {
+            isEnabled(LogLevel.INFO) >> true
         }
 
         project.with {
             ssh {
                 outputLogLevel = LogLevel.INFO
-                logger = loggerMock
             }
             task(type: SshTask, 'testTask') {
                 session(remotes.testServer) {
@@ -173,7 +172,7 @@ class CommandExecutionTest extends Specification {
 
         then:
         logMessages.each {
-            1 * loggerMock.log(LogLevel.INFO, it)
+            1 * logger.log(LogLevel.INFO, it)
         }
 
         where:

--- a/src/test/groovy/org/hidetake/gradle/ssh/test/TestDataHelper.groovy
+++ b/src/test/groovy/org/hidetake/gradle/ssh/test/TestDataHelper.groovy
@@ -1,7 +1,6 @@
 package org.hidetake.gradle.ssh.test
 
 import org.gradle.api.logging.LogLevel
-import org.gradle.api.logging.Logger
 import org.hidetake.gradle.ssh.api.Remote
 import org.hidetake.gradle.ssh.api.SessionSpec
 import org.hidetake.gradle.ssh.api.SshSpec
@@ -13,7 +12,6 @@ class TestDataHelper {
             dryRun = false
             retryCount = 1
             retryWaitSec = 1
-            logger = [:] as Logger
             config([myConf: 'myConf'])
             outputLogLevel = LogLevel.LIFECYCLE
             errorLogLevel = LogLevel.LIFECYCLE


### PR DESCRIPTION
Currently the project logger is used for logging operations and command output, but they should be created by `Logging.getLogger()` instead.
This request removes logger from SshSpec and replaces loggers with `Logging.getLogger()`.
Also replaces SLF4J loggers with Gradle loggers.
