### PR TITLE
Adding support to authentication with Putty Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ A remote host object has following properties:
   * `password` - Password for password authentication. (Optional)
   * `identity` - Private key file for public-key authentication. This overrides global identity. (Optional)
   * `passphrase` - Pass phrase for the private key. (Optional)
+  * `usePuttyAgent` - If this flag is set, Putty Agent will be used to authentication. (Optional)
 
 Use `role(name)` to associate the host with roles. A remote host can be associated with multiple roles.
 

--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,8 @@ dependencies {
     compile gradleApi()
     compile localGroovy()
     compile 'com.jcraft:jsch:0.1.50'
+	compile 'com.jcraft:jsch.agentproxy.connector-factory:0.0.7'
+	compile 'com.jcraft:jsch.agentproxy.jsch:0.0.7'
     testCompile 'org.spockframework:spock-core:0.7-groovy-1.8', 'cglib:cglib-nodep:2.2.2'
     testCompile 'org.apache.sshd:sshd-core:0.9.0'
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 description=Gradle SSH Plugin provides remote execution and file transfer capabilities
 group=org.hidetake
-version=0.2.5
+version=0.2.6

--- a/src/main/groovy/org/hidetake/gradle/ssh/api/Remote.groovy
+++ b/src/main/groovy/org/hidetake/gradle/ssh/api/Remote.groovy
@@ -53,6 +53,12 @@ class Remote {
     String passphrase
 
     /**
+     * Use Putty Agent flag.
+     * If <code>true</code>, Putty Agent will be used to authenticate.
+     */
+    boolean usePuttyAgent
+
+    /**
      * Add a role to this remote.
      *
      * @param role

--- a/src/main/groovy/org/hidetake/gradle/ssh/internal/DefaultSshService.groovy
+++ b/src/main/groovy/org/hidetake/gradle/ssh/internal/DefaultSshService.groovy
@@ -3,6 +3,8 @@ package org.hidetake.gradle.ssh.internal
 import com.jcraft.jsch.JSch
 import com.jcraft.jsch.JSchException
 import com.jcraft.jsch.Session
+import com.jcraft.jsch.agentproxy.ConnectorFactory
+import com.jcraft.jsch.agentproxy.RemoteIdentityRepository
 import groovy.util.logging.Slf4j
 import org.hidetake.gradle.ssh.api.SessionSpec
 import org.hidetake.gradle.ssh.api.SshService
@@ -59,7 +61,12 @@ class DefaultSshService implements SshService {
                         jsch.addIdentity(spec.remote.identity.path, spec.remote.passphrase as String)
                     } else if (sshSpec.identity) {
                         jsch.addIdentity(sshSpec.identity.path, sshSpec.passphrase as String)
-                    }
+                    } else if (spec.remote.usePuttyAgent) {
+						def connectorFactory = ConnectorFactory.getDefault()
+						def connector = connectorFactory.createConnector()
+						def identityRepository = new RemoteIdentityRepository(connector)
+						jsch.setIdentityRepository(identityRepository)
+					}
 
                     session.connect()
                     sessions.put(spec, session)


### PR DESCRIPTION
Hi,

At beginning I want to say: thank you for this plugin. This tool is very useful for me.
I added support to authentication with Putty Agent. If you are interested to use these changes, you can do that (check firstly of course this solution). I will be honored. :-)

And here is a simple example of usage (I assume that the private key is added to Putty Agent):

``` groovy
apply plugin: 'ssh'

remotes {
    example {
        host = 'example.com'
        port = 22
        user = 'username'
        usePuttyAgent = true
    }
}

ssh {
    knownHosts = allowAnyHosts
}


buildscript {
    repositories {
        mavenCentral()
        dependencies {
            classpath 'org.hidetake:gradle-ssh-plugin:0.2.6'
        }
    }
}

task sshtest() << {
    sshexec {               
        session(remotes.example) {
            execute('ls -la')
        }
    }
}
```

Greetings,
Jarek
