### PR TITLE
Fixed JSch version for compile and test

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,14 @@ dependencies {
     testCompile 'org.apache.sshd:sshd-core:0.9.0'
 }
 
+// Exclude bundled JSch from all classpath.
+// Newer JSch will be used when the plugin is applied.
+final bundled = ['jsch-0.1.46.jar']
+sourceSets.all {
+    compileClasspath -= compileClasspath.filter { it.name in bundled }
+    runtimeClasspath -= runtimeClasspath.filter { it.name in bundled }
+}
+
 task javadocJar(type: Jar, dependsOn: groovydoc) {
     from "${buildDir}/docs/groovydoc"
     classifier = 'javadoc'

--- a/src/test/groovy/org/hidetake/gradle/ssh/server/AuthenticationSpec.groovy
+++ b/src/test/groovy/org/hidetake/gradle/ssh/server/AuthenticationSpec.groovy
@@ -229,7 +229,7 @@ class AuthenticationSpec extends Specification {
         then:
         TaskExecutionException e = thrown()
         e.cause.cause instanceof JSchException
-        e.cause.cause.message == 'Auth fail'
+        e.cause.cause.message == 'USERAUTH fail'
     }
 
     def "remote specific identity overrides global one"() {
@@ -258,7 +258,7 @@ class AuthenticationSpec extends Specification {
         then:
         TaskExecutionException e = thrown()
         e.cause.cause instanceof JSchException
-        e.cause.cause.message == 'Auth fail'
+        e.cause.cause.message == 'USERAUTH fail'
     }
 
     static identityFile(String name) {


### PR DESCRIPTION
This pull request fixes main and test classpath to exclude JSch 0.1.46 bundled with Gradle. All JSch version used for compile, test and plugin runtime will be same.

This pull request also fixes assertion of error message which is different between 0.1.46 and 0.1.50.
