### PR TITLE
Show progress information for file transfer

### DIFF
--- a/acceptance-test/features.gradle
+++ b/acceptance-test/features.gradle
@@ -445,6 +445,29 @@ task putAndGetFiles(type: SshTask, dependsOn: 'setupBuildDir') {
 }
 
 
+feature('sending files to the remote host and acquiring result files') {
+    task 'getLargeFile'
+    category 'aggressiveTest'
+}
+
+task getLargeFile(type: SshTask, dependsOn: 'setupBuildDir') {
+    finalizedBy 'cleanRemoteTemp'
+
+    doFirst {
+        ext.sizeX = 1024 * 256
+        ext.localX = file("$buildDir/local-${randomInt()}")
+        ext.pathX = remoteTempPath('X')
+    }
+    session(remotes.localhost) {
+        execute("dd if=/dev/zero of=$pathX bs=1024 count=$sizeX")
+        get(pathX, localX.path)
+    }
+    doLast {
+        assert localX.size() == 1024 * sizeX
+    }
+}
+
+
 task setupBuildDir(type: Delete) {
     delete buildDir
     doLast {

--- a/src/main/groovy/org/hidetake/gradle/ssh/internal/DefaultOperationHandler.groovy
+++ b/src/main/groovy/org/hidetake/gradle/ssh/internal/DefaultOperationHandler.groovy
@@ -10,6 +10,7 @@ import org.codehaus.groovy.tools.Utilities
 import org.hidetake.gradle.ssh.api.*
 import org.hidetake.gradle.ssh.api.operation.ExecutionSettings
 import org.hidetake.gradle.ssh.api.operation.ShellSettings
+import org.hidetake.gradle.ssh.internal.operation.FileTransferLogger
 import org.hidetake.gradle.ssh.internal.session.ChannelManager
 
 /**
@@ -180,9 +181,7 @@ class DefaultOperationHandler extends AbstractOperationHandler {
 
         try {
             channel.connect()
-            log.info("Channel #${channel.id} has been opened")
-            channel.get(remote, local)
-            log.info("Channel #${channel.id} has been closed with exit status ${channel.exitStatus}")
+            channel.get(remote, local, new FileTransferLogger())
         } finally {
             channel.disconnect()
         }
@@ -201,9 +200,7 @@ class DefaultOperationHandler extends AbstractOperationHandler {
 
         try {
             channel.connect()
-            log.info("Channel #${channel.id} has been opened")
-            channel.put(local, remote, ChannelSftp.OVERWRITE)
-            log.info("Channel #${channel.id} has been closed with exit status ${channel.exitStatus}")
+            channel.put(local, remote, new FileTransferLogger(), ChannelSftp.OVERWRITE)
         } finally {
             channel.disconnect()
         }

--- a/src/main/groovy/org/hidetake/gradle/ssh/internal/operation/FileTransferLogger.groovy
+++ b/src/main/groovy/org/hidetake/gradle/ssh/internal/operation/FileTransferLogger.groovy
@@ -1,0 +1,92 @@
+package org.hidetake.gradle.ssh.internal.operation
+
+import com.jcraft.jsch.SftpProgressMonitor
+import groovy.transform.TupleConstructor
+import groovy.util.logging.Slf4j
+
+import static java.lang.String.format
+
+/**
+ * Logger for file transfer.
+ *
+ * @author hidetake.org
+ */
+@Slf4j
+class FileTransferLogger implements SftpProgressMonitor {
+    protected static final LOG_INTERVAL_MILLIS = 3000L
+
+    protected Status status
+
+    @Override
+    void init(int op, String src, String dest, long max) {
+        status = new Status(max)
+        log.info("Starting transfer ${formatBytes(status.maxSize)}.")
+    }
+
+    @Override
+    boolean count(long count) {
+        status << count
+        if (status.elapsedTimeFromCheckPoint > LOG_INTERVAL_MILLIS) {
+            status.checkPoint()
+            log.info("Transferred ${status.percent}% in ${formatTime(status.elapsedTime)}.")
+        }
+        true
+    }
+
+    @Override
+    void end() {
+        log.info("Finished transfer ${formatBytes(status.transferredSize)} " +
+                 "(${formatKBytes(status.bytesPerSecond)}/s). " +
+                 "Took ${formatTime(status.elapsedTime)}.")
+    }
+
+    private static formatBytes(long number) {
+        format('%,d bytes', number)
+    }
+
+    private static formatKBytes(long number) {
+        format('%,d kB', number / 1000 as long)
+    }
+
+    private static formatTime(long number) {
+        format('%.3f secs', number / 1000.0 as double)
+    }
+
+    @TupleConstructor
+    static class Status {
+        final long maxSize = 0
+        long transferredSize = 0
+
+        final long startedTime = currentTime()
+        long lastCheckPointTime = currentTime()
+
+        Status leftShift(long size) {
+            transferredSize += size
+            this
+        }
+
+        int getPercent() {
+            maxSize ? 100 * transferredSize / maxSize : 0
+        }
+
+        long getBytesPerSecond() {
+            1000 * transferredSize / elapsedTime
+        }
+
+        long getElapsedTime() {
+            currentTime() - startedTime
+        }
+
+        void checkPoint() {
+            lastCheckPointTime = currentTime()
+        }
+
+        long getElapsedTimeFromCheckPoint() {
+            currentTime() - lastCheckPointTime
+        }
+
+        static long currentTime() {
+            System.currentTimeMillis()
+        }
+    }
+}

--- a/src/test/groovy/org/hidetake/gradle/ssh/internal/operation/FileTransferLoggerSpec.groovy
+++ b/src/test/groovy/org/hidetake/gradle/ssh/internal/operation/FileTransferLoggerSpec.groovy
@@ -1,0 +1,163 @@
+package org.hidetake.gradle.ssh.internal.operation
+
+import spock.lang.Specification
+import spock.util.mop.ConfineMetaClassChanges
+
+import static org.hidetake.gradle.ssh.internal.operation.FileTransferLogger.LOG_INTERVAL_MILLIS
+
+class FileTransferLoggerSpec extends Specification {
+
+    def "status is initialized when init() is called"() {
+        given:
+        def logger = new FileTransferLogger()
+
+        when: null
+        then: logger.status == null
+
+        when: logger.init(0, 'source', 'destination', 1000)
+        then: logger.status
+        and:  logger.status.maxSize == 1000
+    }
+
+    def "status is updated when count() is called"() {
+        given:
+        def logger = new FileTransferLogger()
+        logger.init(0, 'source', 'destination', 1000)
+
+        when: logger.count(300)
+        then: logger.status.transferredSize == 300
+
+        when: logger.count(500)
+        then: logger.status.transferredSize == 800
+    }
+
+    def "checkpoint is called when elapsed time exceeds interval"() {
+        given:
+        def logger = new FileTransferLogger()
+        logger.status = Mock(FileTransferLogger.Status)
+
+        when: logger.count(300)
+        then: 1 * logger.status.leftShift(300)
+        then: 1 * logger.status.elapsedTimeFromCheckPoint >> (LOG_INTERVAL_MILLIS - 1)
+        then: 0 * logger.status.checkPoint()
+
+        when: logger.count(400)
+        then: 1 * logger.status.leftShift(400)
+        then: 1 * logger.status.elapsedTimeFromCheckPoint >> LOG_INTERVAL_MILLIS
+        then: 0 * logger.status.checkPoint()
+
+        when: logger.count(500)
+        then: 1 * logger.status.leftShift(500)
+        then: 1 * logger.status.elapsedTimeFromCheckPoint >> (LOG_INTERVAL_MILLIS + 1)
+        then: 1 * logger.status.checkPoint()
+    }
+
+    def "end"() {
+        given:
+        def logger = new FileTransferLogger()
+        logger.init(0, 'source', 'destination', 1000)
+
+        when:
+        logger.end()
+
+        then:
+        noExceptionThrown()
+    }
+
+
+
+    def "initialize status"() {
+        given:
+        def status = new FileTransferLogger.Status(2000)
+
+        when:
+        null
+
+        then:
+        status.maxSize == 2000
+        status.transferredSize == 0
+        status.percent == 0
+    }
+
+    def "count up"() {
+        given:
+        def status = new FileTransferLogger.Status(5000)
+
+        when:
+        status << 2000
+
+        then:
+        status.maxSize == 5000
+        status.transferredSize == 2000
+        status.percent == 40
+
+        when:
+        status << 2000
+
+        then:
+        status.maxSize == 5000
+        status.transferredSize == 4000
+        status.percent == 80
+
+        when:
+        status << 1000
+
+        then:
+        status.maxSize == 5000
+        status.transferredSize == 5000
+        status.percent == 100
+    }
+
+    @ConfineMetaClassChanges(FileTransferLogger.Status)
+    def "get elapsed time"() {
+        given:
+        FileTransferLogger.Status.metaClass.static.currentTime = { -> 100 }
+        def status = new FileTransferLogger.Status(1000)
+
+        when: FileTransferLogger.Status.metaClass.static.currentTime = { -> 300 }
+        then: status.elapsedTime == 200
+
+        when: FileTransferLogger.Status.metaClass.static.currentTime = { -> 600 }
+        then: status.elapsedTime == 500
+    }
+
+    @ConfineMetaClassChanges(FileTransferLogger.Status)
+    def "get elapsed time from checkpoint"() {
+        given:
+        FileTransferLogger.Status.metaClass.static.currentTime = { -> 100 }
+        def status = new FileTransferLogger.Status(1000)
+
+        when: FileTransferLogger.Status.metaClass.static.currentTime = { -> 300 }
+        and:  status.checkPoint()
+        then: status.elapsedTimeFromCheckPoint == 0
+
+        when: FileTransferLogger.Status.metaClass.static.currentTime = { -> 600 }
+        then: status.elapsedTimeFromCheckPoint == 300
+
+        when: FileTransferLogger.Status.metaClass.static.currentTime = { -> 800 }
+        then: status.elapsedTimeFromCheckPoint == 500
+
+        when: FileTransferLogger.Status.metaClass.static.currentTime = { -> 900 }
+        and:  status.checkPoint()
+        then: status.elapsedTimeFromCheckPoint == 0
+
+        when: FileTransferLogger.Status.metaClass.static.currentTime = { -> 1000 }
+        then: status.elapsedTimeFromCheckPoint == 100
+    }
+
+    @ConfineMetaClassChanges(FileTransferLogger.Status)
+    def "get bytes per second"() {
+        given:
+        FileTransferLogger.Status.metaClass.static.currentTime = { -> 1000 }
+        def status = new FileTransferLogger.Status(1000)
+
+        when: FileTransferLogger.Status.metaClass.static.currentTime = { -> 3000 }
+        and:  status << 500
+        then: status.bytesPerSecond == (500 /* bytes */ / 2 /* sec */)
+
+        when: FileTransferLogger.Status.metaClass.static.currentTime = { -> 6000 }
+        and:  status << 300
+        then: status.bytesPerSecond == (800 /* bytes */ / 5 /* sec */)
+    }
+
+}


### PR DESCRIPTION
See #62.

For example:

```
Get a remote file (/tmp/fixture-9260-X) to local (/home/...)
Starting transfer 268,435,456 bytes.
Transferred 6% in 3.004 secs.
Transferred 36% in 6.117 secs.
Transferred 70% in 9.117 secs.
Finished transfer 268,435,456 bytes (23,245 kB/s). Took 11.549 secs.
```
