### PR TITLE
Avoid prompting for Kerberos username/password under Java 7

### DIFF
--- a/src/main/groovy/org/hidetake/gradle/ssh/internal/ssh/DefaultConnectionManager.groovy
+++ b/src/main/groovy/org/hidetake/gradle/ssh/internal/ssh/DefaultConnectionManager.groovy
@@ -90,6 +90,8 @@ class DefaultConnectionManager implements ConnectionManager {
                 }
             }
 
+            session.setConfig('PreferredAuthentications', 'publickey,keyboard-interactive,password')
+
             session.connect()
             log.info("Established a session to $remote via $host:$port")
             sessions.add(session)


### PR DESCRIPTION
This pull request will fix issue #82.
