### PR TITLE
Add "archiveDependencies" task to enable offline execution

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,3 +60,13 @@ if (gradle.startParameter.taskNames.contains('publishMavenCentral')) {
 task wrapper(type: Wrapper) {
     gradleVersion = '1.10'
 }
+
+task archiveDependencies(type: Zip, dependsOn: jar) {
+    classifier = 'all'
+    final excludeLibs = ['jsch-0.1.46.jar']
+    runtimeLibs = configurations.runtime - configurations.runtime.filter{ it.name in excludeLibs }
+    into('dep-libs') {
+        from runtimeLibs
+        from 'build/libs'
+    }
+}


### PR DESCRIPTION
I've added "archiveDependencies" task. It gathers all dependent libs to execute gradle-ssh-plugin at offline.
To see detailed background/motivation/usecase, please refer http://qiita.com/nobusue/items/e93e928b937c5c8eb4e6 (sorry in Japanese only).
