### PR TITLE
Proxy feature

### DIFF
--- a/src/main/groovy/org/hidetake/gradle/ssh/internal/connection/DefaultProxyValidator.groovy
+++ b/src/main/groovy/org/hidetake/gradle/ssh/internal/connection/DefaultProxyValidator.groovy
@@ -1,0 +1,70 @@
+package org.hidetake.gradle.ssh.internal.connection
+
+import org.hidetake.gradle.ssh.plugin.Proxy
+import org.hidetake.gradle.ssh.plugin.ProxyType
+
+import static org.hidetake.gradle.ssh.plugin.ProxyType.*
+/**
+ * Basic validation and defaults for proxied connections created by 
+ * {@link DefaultConnectionManager}.
+ *  
+ * @author mlipper
+ *
+ */
+class DefaultProxyValidator {
+	protected static final SOCKS_DEFAULT_VERSION = 5
+	protected static final SOCKS_SUPPORTED_VERSIONS = 4..5
+
+	private final Proxy proxy
+	private final Map report
+	
+	DefaultProxyValidator(Proxy proxy1) {
+		this.proxy = proxy1
+		this.report = [error:null,warnings:[]]
+		createReport()
+	}
+	
+	String error() { report.error }
+	
+	List<String> warnings() { report.warnings ?: null }
+	
+	private void createReport() {
+		validateProxyType()
+		ensureSocksVersion()
+		checkCredentials()
+	}
+	
+	private void validateProxyType() {
+		if(!ProxyType.values().contains(proxy.type)) {
+			report.error = "Unsupported ProxyType ${proxy.type}. Supported types: ${ProxyType.collect {"$it"}.join(', ')}."
+		}
+	}
+	
+	private void checkCredentials() {
+		// DefaultConnectionManager ignores authentication credentials when 
+		// creating proxy server connections unless both proxy.user and 
+		// proxy.password are set
+		if(proxy.user && !proxy.password) {
+			addWarning("proxy.user is set but proxy.password is null. Credentials are ignored for proxy '${proxy.name}'")
+		}
+		if(!proxy.user && proxy.password) {
+			addWarning("proxy.password is set but proxy.user is null. Credentials are ignored for proxy '${proxy.name}'")
+		}
+	}
+	
+	private void ensureSocksVersion() {
+		def v = proxy.socksVersion
+		if(SOCKS == proxy.type && !SOCKS_SUPPORTED_VERSIONS.contains(v)) {
+			if(v == 0) {
+				addWarning("Using SOCKS v$SOCKS_DEFAULT_VERSION since proxy.socksVersion is not set.")
+			} else {
+				addWarning("Using SOCKS v$SOCKS_DEFAULT_VERSION since proxy.socksVersion is set to ${proxy.socksVersion} which is not supported by this implementation.")
+			}
+			proxy.socksVersion = SOCKS_DEFAULT_VERSION
+		}
+	}
+
+	private void addWarning(String message) {
+		report.warnings.add(message)
+	}
+}

--- a/src/main/groovy/org/hidetake/gradle/ssh/plugin/ConnectionSettings.groovy
+++ b/src/main/groovy/org/hidetake/gradle/ssh/plugin/ConnectionSettings.groovy
@@ -54,6 +54,12 @@ class ConnectionSettings extends Settings<ConnectionSettings> {
      * Retry count for connecting to a host.
      */
     Integer retryCount
+    
+    /**
+     * Proxy configuration for connecting to a host.
+     * This may be null. 
+     */
+    Proxy proxy
 
     /**
      * Interval time in seconds between retries.
@@ -80,7 +86,8 @@ class ConnectionSettings extends Settings<ConnectionSettings> {
                 agent:        findNotNull(right.agent, agent),
                 knownHosts:   findNotNull(right.knownHosts, knownHosts),
                 retryCount:   findNotNull(right.retryCount, retryCount),
-                retryWaitSec: findNotNull(right.retryWaitSec, retryWaitSec)
+                retryWaitSec: findNotNull(right.retryWaitSec, retryWaitSec),
+                proxy:        findNotNull(right.proxy, proxy)
         )
     }
 

--- a/src/main/groovy/org/hidetake/gradle/ssh/plugin/Proxy.groovy
+++ b/src/main/groovy/org/hidetake/gradle/ssh/plugin/Proxy.groovy
@@ -1,0 +1,66 @@
+package org.hidetake.gradle.ssh.plugin
+
+import groovy.transform.ToString
+
+/**
+ * Represents a connection proxy to use when establishing a {@link Session}. An instance
+ * of this class be shared by multiple {@link Remote}s.
+ *
+ * @author mlipper
+ *
+ */
+@ToString(excludes = 'password')
+class Proxy {
+    /**
+     * Adds all type of the {@link ProxyType},
+     * in order to omit import in a build script.
+     */
+	static {
+        ProxyType.values().each { proxyType ->
+            Proxy.metaClass[proxyType.name()] = proxyType
+        }
+    }
+
+	/**
+	 * Name of this instance.
+	 */
+	final String name
+
+	def Proxy(String name1) {
+		name = name1
+		assert name
+	}
+
+    /**
+     * Proxy protocol type
+     */
+    ProxyType type
+	
+	/**
+	 * SOCKS protocol version. 
+	 * This should be set when using ProxyType.SOCKS.
+	 */
+	int socksVersion
+
+    /**
+     * Port.
+     */
+    int port
+
+    /**
+     * Proxy host.
+     */
+    String host
+
+   /**
+     * Proxy user. 
+     * This may be null.
+     */
+    String user    
+
+   /**
+     * Proxy password. 
+     * This may be null.
+     */
+    String password
+}

--- a/src/main/groovy/org/hidetake/gradle/ssh/plugin/ProxyType.groovy
+++ b/src/main/groovy/org/hidetake/gradle/ssh/plugin/ProxyType.groovy
@@ -1,0 +1,6 @@
+package org.hidetake.gradle.ssh.plugin;
+
+enum ProxyType {
+    HTTP,
+    SOCKS
+}

--- a/src/main/groovy/org/hidetake/gradle/ssh/plugin/Remote.groovy
+++ b/src/main/groovy/org/hidetake/gradle/ssh/plugin/Remote.groovy
@@ -36,6 +36,12 @@ class Remote {
      */
     Remote gateway
 
+	/**
+	 * Proxy to use when establishing a connection.
+	 * This may be null.
+	 */
+	Proxy proxy
+
     /**
      * Roles.
      */

--- a/src/main/groovy/org/hidetake/gradle/ssh/plugin/SshPlugin.groovy
+++ b/src/main/groovy/org/hidetake/gradle/ssh/plugin/SshPlugin.groovy
@@ -16,6 +16,7 @@ class SshPlugin implements Plugin<Project> {
     void apply(Project project) {
         project.extensions.ssh = new CompositeSettings()
         project.extensions.remotes = createRemoteContainer(project)
+        project.extensions.proxies = createProxyContainer(project)
 
         project.convention.plugins.ssh = new Convention(project)
     }
@@ -28,6 +29,16 @@ class SshPlugin implements Plugin<Project> {
             remotes.addAll(parentRemotes)
         }
         remotes
+    }
+
+    private static createProxyContainer(Project project) {
+		def proxies = project.container(Proxy)
+		def parentProxies = project.parent?.extensions?.findByName('proxies')
+		if (parentProxies instanceof NamedDomainObjectContainer<Proxy>) {
+			proxies.addAll(parentProxies)
+		}
+
+		proxies
     }
 
     static class Convention {

--- a/src/test/groovy/org/hidetake/gradle/ssh/internal/DefaultSshTaskHandlerSpec.groovy
+++ b/src/test/groovy/org/hidetake/gradle/ssh/internal/DefaultSshTaskHandlerSpec.groovy
@@ -1,13 +1,16 @@
 package org.hidetake.gradle.ssh.internal
 
+import org.hidetake.gradle.ssh.internal.DefaultSshTaskHandler;
 import org.hidetake.gradle.ssh.internal.connection.ConnectionManager
 import org.hidetake.gradle.ssh.internal.connection.ConnectionService
 import org.hidetake.gradle.ssh.internal.session.SessionService
 import org.hidetake.gradle.ssh.plugin.CompositeSettings
 import org.hidetake.gradle.ssh.plugin.ConnectionSettings
 import org.hidetake.gradle.ssh.plugin.OperationSettings
+import org.hidetake.gradle.ssh.plugin.Proxy
 import org.hidetake.gradle.ssh.plugin.Remote
 import org.hidetake.gradle.ssh.plugin.session.SessionHandler
+
 import spock.lang.Specification
 import spock.lang.Unroll
 import spock.util.mop.ConfineMetaClassChanges
@@ -84,6 +87,24 @@ class DefaultSshTaskHandlerSpec extends Specification {
         noExceptionThrown()
     }
 
+    def "add session for remote with proxy"() {
+        given:
+        def proxy = new Proxy('myProxy')
+        def remote = new Remote('myRemote')
+        remote.user = 'myUser'
+        remote.host = 'myHost'
+        remote.proxy = proxy
+        def closure = { assert false }
+
+        when:
+        sshTaskDelegate.session(remote, closure)
+
+        then:
+        noExceptionThrown()
+    }
+
+
+    
     def "add session for empty remotes throws assertion error"() {
         given:
         def closure = { assert false }

--- a/src/test/groovy/org/hidetake/gradle/ssh/internal/connection/DefaultProxyValidatorSpec.groovy
+++ b/src/test/groovy/org/hidetake/gradle/ssh/internal/connection/DefaultProxyValidatorSpec.groovy
@@ -1,0 +1,181 @@
+package org.hidetake.gradle.ssh.internal.connection
+
+import spock.lang.Specification 
+import org.hidetake.gradle.ssh.plugin.Proxy
+import org.hidetake.gradle.ssh.plugin.ProxyType
+
+import static org.hidetake.gradle.ssh.plugin.ProxyType.*
+
+class DefaultProxyValidatorSpec extends Specification {
+	
+	def "proxy with user and password generates no warnings"() {
+		given:
+			def proxy = new Proxy("proxy")
+			proxy.type = HTTP
+			proxy.user = "jsmith"
+			proxy.password = "s3cr3t"
+			def validator = new DefaultProxyValidator(proxy)
+	
+		when:
+			def errorMsg = validator.error()
+			def warnMsgs = validator.warnings()
+			
+		then:
+			errorMsg == null
+			warnMsgs == null
+	}
+	
+	def "proxy without user or password generates no warnings"() {
+		given:
+			def proxy = new Proxy("proxy")
+			proxy.type = HTTP
+			proxy.user = null
+			proxy.password = null
+			def validator = new DefaultProxyValidator(proxy)
+	
+		when:
+			def errorMsg = validator.error()
+			def warnMsgs = validator.warnings()
+			
+		then:
+			errorMsg == null
+			warnMsgs == null
+	}
+	
+	def "proxy with user but no password generates warning"() {
+		given:
+			def proxy = new Proxy("proxy")
+			proxy.type = HTTP
+			proxy.user = "jsmith"
+			proxy.password = null
+			def validator = new DefaultProxyValidator(proxy)
+	
+		when:
+			def errorMsg = validator.error()
+			def warnMsgs = validator.warnings()
+			
+		then:
+			errorMsg == null
+			warnMsgs.size() == 1
+	}
+	
+	def "proxy with password but no user generates warning"() {
+		given:
+			def proxy = new Proxy("proxy")
+			proxy.type = HTTP
+			proxy.user = null
+			proxy.password = "s3cr3t"
+			def validator = new DefaultProxyValidator(proxy)
+	
+		when:
+			def errorMsg = validator.error()
+			def warnMsgs = validator.warnings()
+			
+		then:
+			errorMsg == null
+			warnMsgs.size() == 1
+	}
+	
+	def "proxy with supported socksVersion generates no warnings"() {
+		given:
+			def proxy = new Proxy("proxy")
+			proxy.type = SOCKS
+			proxy.socksVersion = 5
+			proxy.user = "jsmith"
+			proxy.password = "s3cr3t"
+			def validator = new DefaultProxyValidator(proxy)
+	
+		when:
+			def errorMsg = validator.error()
+			def warnMsgs = validator.warnings()
+			
+		then:
+			errorMsg == null
+			warnMsgs == null
+	}
+	
+	def "proxy with unsupported socksVersion generates warning"() {
+		given:
+			def proxy = new Proxy("proxy")
+			proxy.type = SOCKS
+			proxy.socksVersion = 8
+			proxy.user = "jsmith"
+			proxy.password = "s3cr3t"
+			def validator = new DefaultProxyValidator(proxy)
+	
+		when:
+			def errorMsg = validator.error()
+			def warnMsgs = validator.warnings()
+			
+		then:
+			errorMsg == null
+			warnMsgs.size() == 1
+	}
+	
+	def "proxy without socksVersion generates warning"() {
+		given:
+			def proxy = new Proxy("proxy")
+			proxy.type = SOCKS
+			proxy.user = "jsmith"
+			proxy.password = "s3cr3t"
+			def validator = new DefaultProxyValidator(proxy)
+	
+		when:
+			def errorMsg = validator.error()
+			def warnMsgs = validator.warnings()
+			
+		then:
+			errorMsg == null
+			warnMsgs.size() == 1
+	}
+	
+	def "proxy with null type is an error"() {
+		given:
+			def proxy = new Proxy("proxy")
+			proxy.user = "jsmith"
+			proxy.password = "s3cr3t"
+			def validator = new DefaultProxyValidator(proxy)
+	
+		when:
+			def errorMsg = validator.error()
+			def warnMsgs = validator.warnings()
+			
+		then:
+			errorMsg != null
+			warnMsgs == null
+	}
+	
+	def "proxy without user, password, or socksVersion generates one warning"() {
+		given:
+			def proxy = new Proxy("proxy")
+			proxy.type = SOCKS
+			proxy.user = null
+			proxy.password = null
+			def validator = new DefaultProxyValidator(proxy)
+	
+		when:
+			def errorMsg = validator.error()
+			def warnMsgs = validator.warnings()
+			
+		then:
+			errorMsg == null
+			warnMsgs.size() == 1
+	}
+
+	def "proxy with user, no password, and no socksVersion generates two warnings"() {
+		given:
+			def proxy = new Proxy("proxy")
+			proxy.type = SOCKS
+			proxy.user = "jsmith"
+			proxy.password = null
+			def validator = new DefaultProxyValidator(proxy)
+	
+		when:
+			def errorMsg = validator.error()
+			def warnMsgs = validator.warnings()
+			
+		then:
+			errorMsg == null
+			warnMsgs.size() == 2
+	}
+}

--- a/src/test/groovy/org/hidetake/gradle/ssh/plugin/ConnectionSettingsSpec.groovy
+++ b/src/test/groovy/org/hidetake/gradle/ssh/plugin/ConnectionSettingsSpec.groovy
@@ -1,10 +1,17 @@
 package org.hidetake.gradle.ssh.plugin
 
+import spock.lang.Shared;
 import spock.lang.Specification
 import spock.lang.Unroll
 
 class ConnectionSettingsSpec extends Specification {
 
+    @Shared
+    Proxy proxyDefault = new Proxy("proxyDefault")
+    
+    @Shared
+    Proxy proxyOverride =  new Proxy("proxyOverride")
+    
     def "merge with empty"() {
         given:
         def settings = new ConnectionSettings(identity: new File('id_rsa'))

--- a/src/test/groovy/org/hidetake/gradle/ssh/plugin/ProxySpec.groovy
+++ b/src/test/groovy/org/hidetake/gradle/ssh/plugin/ProxySpec.groovy
@@ -1,0 +1,28 @@
+package org.hidetake.gradle.ssh.plugin
+
+import spock.lang.Specification
+
+import static ProxyType.SOCKS
+
+class ProxySpec extends Specification {
+
+    def "result of toString() does not contain password"() {
+        given:
+        def proxy = new Proxy('theProxy')
+        proxy.host = 'theHost'
+        proxy.user = 'theUser'
+        proxy.password = 'thePassword'
+        proxy.type = SOCKS
+
+        when:
+        def result = proxy.toString()
+
+        then:
+        result.contains('theProxy')
+        result.contains('theHost')
+        result.contains('theUser')
+        !result.contains('thePassword')
+        result.contains(SOCKS.toString())
+    }
+
+}


### PR DESCRIPTION
Initial implementation of gradle-ssh-plugin enhancement #88 to allow connections to be made through a proxy. Almost all proposed changes are additive and do not refactor existing code. Please let me know of design or implementation issues/improvements that are needed. 
#### New Features
- proxy definitions created using top-level script block
- global connection proxying
- remote-specific connection proxying which overrides global proxy if set
- tasks can use both proxied and non-proxied remotes in a single session closure
#### Caveats
- I am new to Groovy/Gradle/Spock and code may not be sufficiently Groovy-ish/Spock-ish/Gradle-ish
- Proxy implementation may need better test coverage (need some guidance on project testing approach)
- No additional server Integration or acceptance test coverage (need some guidance on project testing approach)
#### Build Status
- Travis CI build passing
- All tests run by test task are passing
- All tests run by serverIntegrationTest task are passing except for FileTransferSpec on Windows and HostKeyCheckingSpec on OSX. Both failures are documented as known issues already.
- I have not written any documentation beyond GroovyDoc. I will do that next if you think this initial request makes sense 
