### PR TITLE
Fix error if the parent project did not apply the plugin

### DIFF
--- a/src/main/groovy/org/hidetake/gradle/ssh/plugin/SshPlugin.groovy
+++ b/src/main/groovy/org/hidetake/gradle/ssh/plugin/SshPlugin.groovy
@@ -23,11 +23,9 @@ class SshPlugin implements Plugin<Project> {
     private static createRemoteContainer(Project project) {
         def remotes = project.container(Remote)
         remotes.metaClass.mixin(RemoteContainerExtension)
-        if (project.parent) {
-            def parentRemotes = project.parent.extensions.remotes as NamedDomainObjectContainer<Remote>
-            if (parentRemotes) {
-                remotes.addAll(parentRemotes)
-            }
+        def parentRemotes = project.parent?.extensions?.findByName('remotes')
+        if (parentRemotes instanceof NamedDomainObjectContainer<Remote>) {
+            remotes.addAll(parentRemotes)
         }
         remotes
     }


### PR DESCRIPTION
This pull request fixes issue #98, using `project.extensions.findByName()` instead of property accessor to prevent the error.
