### PR TITLE
Adding JSch logging

### DIFF
--- a/src/main/groovy/org/hidetake/gradle/ssh/internal/connection/DefaultConnectionManager.groovy
+++ b/src/main/groovy/org/hidetake/gradle/ssh/internal/connection/DefaultConnectionManager.groovy
@@ -1,7 +1,6 @@
 package org.hidetake.gradle.ssh.internal.connection
 
 import com.jcraft.jsch.JSch
-
 import com.jcraft.jsch.Proxy as JschProxy
 import com.jcraft.jsch.ProxyHTTP
 import com.jcraft.jsch.ProxySOCKS4
@@ -28,7 +27,6 @@ class DefaultConnectionManager implements ConnectionManager {
     protected static final LOCALHOST = '127.0.0.1'
 	
     private final ConnectionSettings connectionSettings
-    private final JSch jsch = new JSch()
     private final List<Connection> connections = []
 
     @Lazy
@@ -84,6 +82,9 @@ class DefaultConnectionManager implements ConnectionManager {
         assert settings.retryWaitSec != null, 'retryWaitSec must not be null'
         assert settings.retryCount   >= 0, "retryCount must be zero or positive (remote ${remote.name})"
         assert settings.retryWaitSec >= 0, "retryWaitSec must be zero or positive (remote ${remote.name})"
+
+        JSch.logger = JSchLogger.instance
+        def jsch = new JSch()
 
         if (settings.knownHosts == ConnectionSettings.Constants.allowAnyHosts) {
             jsch.setConfig('StrictHostKeyChecking', 'no')

--- a/src/main/groovy/org/hidetake/gradle/ssh/internal/connection/JSchLogger.groovy
+++ b/src/main/groovy/org/hidetake/gradle/ssh/internal/connection/JSchLogger.groovy
@@ -1,0 +1,46 @@
+package org.hidetake.gradle.ssh.internal.connection
+
+import com.jcraft.jsch.Logger
+import groovy.util.logging.Slf4j
+
+/**
+ * A logger which bridges JSch and SLF4J.
+ *
+ * @author Hidetake Iwata
+ */
+@Singleton
+@Slf4j
+class JSchLogger implements Logger {
+    @Override
+    boolean isEnabled(int logLevel) {
+        switch (logLevel) {
+            case DEBUG: return log.isDebugEnabled()
+            case INFO:  return log.isInfoEnabled()
+            case WARN:  return log.isWarnEnabled()
+            case ERROR: return log.isErrorEnabled()
+            case FATAL: return log.isErrorEnabled()
+            default:    return false
+        }
+    }
+
+    @Override
+    void log(int logLevel, String message) {
+        switch (logLevel) {
+            case DEBUG:
+                log.debug("JSch: $message")
+                break
+            case INFO:
+                log.info("JSch: $message")
+                break
+            case WARN:
+                log.warn("JSch: $message")
+                break
+            case ERROR:
+                log.error("JSch: $message")
+                break
+            case FATAL:
+                log.error("JSch: $message")
+                break
+        }
+    }
+}


### PR DESCRIPTION
This pull request adds the feature showing log from JSch as follows.

```
:executeCommand
Executing task ':executeCommand' (up-to-date check took 0.001 secs) due to:
  Task has not declared any outputs.
JSch: Connecting to localhost port 22
JSch: Connection established
JSch: Remote version string: SSH-2.0-OpenSSH_6.2
JSch: Local version string: SSH-2.0-JSCH-0.1.51
...
```
