### PR TITLE
Fix file transfer failure and refactor test

### DIFF
--- a/src/main/groovy/org/hidetake/gradle/ssh/internal/operation/FileTransferLogger.groovy
+++ b/src/main/groovy/org/hidetake/gradle/ssh/internal/operation/FileTransferLogger.groovy
@@ -112,7 +112,7 @@ class FileTransferLogger implements SftpProgressMonitor {
          * @return transfer rate in kbps
          */
         double getKiloBytesPerSecond() {
-            transferredSize / elapsedTime
+            elapsedTime ? transferredSize / elapsedTime : 0
         }
 
         /**

--- a/src/test/groovy/org/hidetake/gradle/ssh/internal/operation/FileTransferLoggerSpec.groovy
+++ b/src/test/groovy/org/hidetake/gradle/ssh/internal/operation/FileTransferLoggerSpec.groovy
@@ -177,4 +177,17 @@ class FileTransferLoggerSpec extends Specification {
         then: status.kiloBytesPerSecond == (9.0 /* kB */ / 5 /* sec */)
     }
 
+    @ConfineMetaClassChanges(FileTransferLogger.Status)
+    def "kiloBytesPerSecond should be zero if no time is elapsed"() {
+        given:
+        FileTransferLogger.Status.metaClass.static.currentTime = { -> 1000 }
+        def status = new FileTransferLogger.Status(10000)
+
+        when: null
+        then: status.kiloBytesPerSecond == 0
+
+        when: status << 5000 /* bytes */
+        then: status.kiloBytesPerSecond == 0
+    }
+
 }


### PR DESCRIPTION
This pull request fixes #105, file transfer eventually fails due to division by zero error. Also refactors the test of progress monitor.

The bug became obvious since Java 8, because probably execution speed has been faster.
