### PR TITLE
Fix cleanup of tests

### DIFF
--- a/src/test/groovy/org/hidetake/gradle/ssh/internal/interaction/LineOutputStreamSpec.groovy
+++ b/src/test/groovy/org/hidetake/gradle/ssh/internal/interaction/LineOutputStreamSpec.groovy
@@ -21,7 +21,7 @@ class LineOutputStreamSpec extends Specification {
         stream.listenLogging(loggingListener)
     }
 
-    def teardown() {
+    def cleanup() {
         stream.close()
     }
 

--- a/src/test/groovy/org/hidetake/gradle/ssh/server/AuthenticationSpec.groovy
+++ b/src/test/groovy/org/hidetake/gradle/ssh/server/AuthenticationSpec.groovy
@@ -36,7 +36,7 @@ class AuthenticationSpec extends Specification {
         }
     }
 
-    def teardown() {
+    def cleanup() {
         server.stop(true)
     }
 

--- a/src/test/groovy/org/hidetake/gradle/ssh/server/BackgroundCommandExecutionSpec.groovy
+++ b/src/test/groovy/org/hidetake/gradle/ssh/server/BackgroundCommandExecutionSpec.groovy
@@ -49,7 +49,7 @@ class BackgroundCommandExecutionSpec extends Specification {
         }
     }
 
-    def teardown() {
+    def cleanup() {
         server.stop(true)
     }
 

--- a/src/test/groovy/org/hidetake/gradle/ssh/server/CommandExecutionSpec.groovy
+++ b/src/test/groovy/org/hidetake/gradle/ssh/server/CommandExecutionSpec.groovy
@@ -48,7 +48,7 @@ class CommandExecutionSpec extends Specification {
         }
     }
 
-    def teardown() {
+    def cleanup() {
         server.stop(true)
     }
 

--- a/src/test/groovy/org/hidetake/gradle/ssh/server/HostKeyCheckingSpec.groovy
+++ b/src/test/groovy/org/hidetake/gradle/ssh/server/HostKeyCheckingSpec.groovy
@@ -54,7 +54,7 @@ class HostKeyCheckingSpec extends Specification {
         }
     }
 
-    def teardown() {
+    def cleanup() {
         server.stop(true)
     }
 

--- a/src/test/groovy/org/hidetake/gradle/ssh/server/PortForwardingSpec.groovy
+++ b/src/test/groovy/org/hidetake/gradle/ssh/server/PortForwardingSpec.groovy
@@ -44,7 +44,7 @@ class PortForwardingSpec extends Specification {
         server
     }
 
-    def teardown() {
+    def cleanup() {
         targetServer.stop(true)
         gateway1Server.stop(true)
         gateway2Server.stop(true)

--- a/src/test/groovy/org/hidetake/gradle/ssh/server/ShellExecutionSpec.groovy
+++ b/src/test/groovy/org/hidetake/gradle/ssh/server/ShellExecutionSpec.groovy
@@ -45,7 +45,7 @@ class ShellExecutionSpec extends Specification {
         }
     }
 
-    def teardown() {
+    def cleanup() {
         server.stop(true)
     }
 

--- a/src/test/groovy/org/hidetake/gradle/ssh/server/SudoCommandExecutionSpec.groovy
+++ b/src/test/groovy/org/hidetake/gradle/ssh/server/SudoCommandExecutionSpec.groovy
@@ -47,7 +47,7 @@ class SudoCommandExecutionSpec extends Specification {
         }
     }
 
-    def teardown() {
+    def cleanup() {
         server.stop(true)
     }
 


### PR DESCRIPTION
This pull request replaces wrong `teardown` with `cleanup`.
