### PR TITLE
Examine jar built with Gradle 1.12 on Gradle 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ install:
   - ./gradlew uploadArchives
 script:
   - ./gradlew check
+  - sed -i -e "s/gradleVersion = '1.12'/gradleVersion = '2.0'/" build.gradle
+  - ./gradlew wrapper
+  - ./gradlew wrapper
   - ./.travis.sh acceptance_test
 after_script:
   - ./gradlew groovydoc


### PR DESCRIPTION
This pull request examines that the release 0.3.x could run on Gradle 2.0.

_(don't merge this)_
