### PR TITLE
Fix secure random egd to avoid slow tests on Linux

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,6 +71,12 @@ if (gradle.startParameter.taskNames.contains('publishMavenCentral')) {
     }
 }
 
+if (System.getProperty('os.name') == 'Linux') {
+    tasks.withType(JavaForkOptions) {
+        systemProperty 'java.security.egd', 'file:/dev/./urandom'
+    }
+}
+
 task wrapper(type: Wrapper) {
     gradleVersion = '1.12'
 }


### PR DESCRIPTION
Apache MINA SSHD server seems to call the secure random generator and cause slow tests on Linux. So this pull request fixes the system property and reduce time to test.

Here is the thread dump during running test.

```
"Test worker" #11 prio=5 os_prio=0 tid=0x00007fd454a6d800 nid=0x6b10 runnable [0x00007fd436011000]
   java.lang.Thread.State: RUNNABLE
        at java.io.FileInputStream.readBytes(Native Method)
        at java.io.FileInputStream.read(FileInputStream.java:234)
        at sun.security.provider.NativePRNG$RandomIO.readFully(NativePRNG.java:410)
        at sun.security.provider.NativePRNG$RandomIO.implGenerateSeed(NativePRNG.java:427)
        - locked <0x00000000c4a408f8> (a java.lang.Object)
        at sun.security.provider.NativePRNG$RandomIO.access$500(NativePRNG.java:329)
        at sun.security.provider.NativePRNG.engineGenerateSeed(NativePRNG.java:224)
        at java.security.SecureRandom.generateSeed(SecureRandom.java:522)
        at org.apache.sshd.common.random.BouncyCastleRandom.<init>(BouncyCastleRandom.java:57)
        at org.apache.sshd.common.random.BouncyCastleRandom$Factory.create(BouncyCastleRandom.java:48)
        at org.apache.sshd.common.random.BouncyCastleRandom$Factory.create(BouncyCastleRandom.java:41)
        at org.apache.sshd.common.random.SingletonRandomFactory.<init>(SingletonRandomFactory.java:37)
        at org.apache.sshd.SshServer.setUpDefaultServer(SshServer.java:389)
        at org.apache.sshd.SshServer$setUpDefaultServer.call(Unknown Source)
        at org.hidetake.gradle.ssh.test.SshServerMock.setUpLocalhostServer(SshServerMock.groovy:54)
        at org.hidetake.gradle.ssh.test.SshServerMock$setUpLocalhostServer.call(Unknown Source)
        at org.hidetake.gradle.ssh.server.AuthenticationSpec.setup(AuthenticationSpec.groovy:26)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:483)
```
