### PR TITLE
Build for running on Java 6 or later

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,9 @@ plugins {
     id 'com.jfrog.bintray' version '0.6'
 }
 
+sourceCompatibility = JavaVersion.VERSION_1_6
+targetCompatibility = JavaVersion.VERSION_1_6
+
 repositories {
     mavenLocal()
     jcenter()


### PR DESCRIPTION
groovy-ssh 0.1.7 can run on Java 6 or later.
