### PR TITLE
Remove sshexec support

### DIFF
--- a/acceptance-test/command-execution.gradle
+++ b/acceptance-test/command-execution.gradle
@@ -37,26 +37,6 @@ task executeCommandWithLogging(type: SshTask) {
 }
 
 
-feature('executing a command by the sshexec method') {
-    task 'executeCommandBySshexec'
-    category 'test'
-}
-
-task executeCommandBySshexec << {
-    def x = randomInt()
-    def y = randomInt()
-    def a = sshexec {
-        session(remotes.localhost) {
-            execute "expr $x + $y"
-        }
-        session(remotes.localhost) {
-            execute "expr $x - $y"
-        }
-    }
-    assert a as int == (x - y)
-}
-
-
 feature('executing commands sequentially') {
     task 'executeSequentially'
     category 'test'
@@ -139,7 +119,7 @@ task executeConcurrently(type: SshTask) {
     }
     doLast {
         // all commands should be completed at this point
-        def result = sshexec {
+        def result = ssh.run {
             session(remotes.localhost) {
                 execute("cat $tempPath")
             }
@@ -156,7 +136,7 @@ feature('handling failure of the remote command') {
 
 task failureStatus << {
     try {
-        sshexec {
+        ssh.run {
             session(remotes.localhost) {
                 execute 'exit 1'
             }
@@ -175,7 +155,7 @@ feature('handling failure of the remote command in background') {
 
 task failureStatusInBackground << {
     try {
-        sshexec {
+        ssh.run {
             session(remotes.localhost) {
                 executeBackground 'exit 1'
             }

--- a/src/main/groovy/org/hidetake/gradle/ssh/plugin/SshPlugin.groovy
+++ b/src/main/groovy/org/hidetake/gradle/ssh/plugin/SshPlugin.groovy
@@ -7,28 +7,22 @@ import org.gradle.api.Project
 import org.hidetake.groovy.ssh.Ssh
 import org.hidetake.groovy.ssh.core.Proxy
 import org.hidetake.groovy.ssh.core.Remote
-import org.hidetake.groovy.ssh.core.RunHandler
-import org.hidetake.groovy.ssh.core.Service
-import org.hidetake.groovy.ssh.core.settings.CompositeSettings
-
-import static org.hidetake.groovy.ssh.util.Utility.callWithDelegate
 
 /**
- * Gradle SSH plugin.
- * This class adds project extension and convention properties.
+ * Main class of Gradle SSH plugin.
  *
- * @author hidetake.org
+ * @author Hidetake Iwata
  */
 @Slf4j
 class SshPlugin implements Plugin<Project> {
     @Override
     void apply(Project project) {
-        //project.extensions.ssh = Ssh.newService()
-
+        project.extensions.ssh = Ssh.newService()
         project.extensions.remotes = createRemoteContainer(project)
         project.extensions.proxies = createProxyContainer(project)
 
-        project.convention.plugins.ssh = new Convention(project)
+        // TODO: remove in future release
+        project.ext.SshTask = SshTask
     }
 
     private static createRemoteContainer(Project project) {
@@ -47,62 +41,13 @@ class SshPlugin implements Plugin<Project> {
 		if (parentProxies instanceof NamedDomainObjectContainer<Proxy>) {
 			proxies.addAll(parentProxies)
 		}
-
 		proxies
-    }
-
-    static class Convention {
-        private final Project project
-
-        private Convention(Project project1) {
-            project = project1
-            assert project
-        }
-
-        /**
-         * Alias to omit import in build script.
-         */
-        @Deprecated
-        final Class SshTask = org.hidetake.gradle.ssh.plugin.SshTask
-
-        final Service ssh = Ssh.newService()
-
-        /**
-         * Set global settings.
-         *
-         * @param closure
-         */
-        @Deprecated
-        void ssh(@DelegatesTo(CompositeSettings) Closure closure) {
-            log.warn 'Deprecated: use ssh.settings {...} instead of ssh {...}'
-            ssh.settings(closure)
-        }
-
-        /**
-         * Execute a SSH closure.
-         *
-         * @param closure closure for {@link RunHandler}
-         * @return returned value of the last session
-         */
-        @Deprecated
-        Object sshexec(@DelegatesTo(RunHandler) Closure closure) {
-            assert closure, 'closure must be given'
-            log.warn 'Deprecated: use ssh.run {...} instead of sshexec {...}'
-            def handler = new RunHandler()
-            handler.metaClass.ssh = { Closure c ->
-                log.warn 'Deprecated: use settings {...} instead of ssh {...} in the sshexec method'
-                handler.settings(c)
-            }
-            callWithDelegate(closure, handler)
-
-            def results = ssh.executor.execute(CompositeSettings.DEFAULT + ssh.settings + handler.settings, handler.sessions)
-            results.empty ? null : results.last()
-        }
     }
 
     /**
      * Alternative entry point for old plugin ID, i.e. 'ssh'.
-     * @deprecated will be removed in future
+     *
+     * @deprecated TODO: remove in future release
      */
     @Slf4j
     @Deprecated

--- a/src/main/groovy/org/hidetake/gradle/ssh/plugin/SshTask.groovy
+++ b/src/main/groovy/org/hidetake/gradle/ssh/plugin/SshTask.groovy
@@ -9,6 +9,8 @@ import org.hidetake.groovy.ssh.core.settings.CompositeSettings
 /**
  * A SSH task for Gradle.
  *
+ * @deprecated TODO: remove in future release
+ *
  * @author hidetake.org
  */
 @Slf4j
@@ -19,7 +21,6 @@ class SshTask extends DefaultTask {
 
     @Deprecated
     void ssh(@DelegatesTo(CompositeSettings) Closure closure) {
-        log.warn 'Deprecated: use settings {...} instead of ssh {...} in the ssh task'
         handler.settings(closure)
     }
 

--- a/src/test/groovy/org/hidetake/gradle/ssh/plugin/DryRunSpec.groovy
+++ b/src/test/groovy/org/hidetake/gradle/ssh/plugin/DryRunSpec.groovy
@@ -12,7 +12,7 @@ class DryRunSpec extends Specification {
         project = ProjectBuilder.builder().build()
         project.with {
             apply plugin: 'org.hidetake.ssh'
-            ssh {
+            ssh.settings {
                 knownHosts = allowAnyHosts
                 dryRun = true
             }

--- a/src/test/groovy/org/hidetake/gradle/ssh/plugin/SshPluginSpec.groovy
+++ b/src/test/groovy/org/hidetake/gradle/ssh/plugin/SshPluginSpec.groovy
@@ -28,15 +28,18 @@ class SshPluginSpec extends Specification {
     def "apply global settings"() {
         given:
         def project = ProjectBuilder.builder().build()
-        project.apply plugin: 'org.hidetake.ssh'
         def globalProxy = new Proxy('globalProxy')
 
         when:
-        project.ssh {
-            dryRun = true
-            retryCount = 1
-            retryWaitSec = 1
-            proxy = globalProxy
+        project.with {
+            apply plugin: 'org.hidetake.ssh'
+
+            ssh.settings {
+                dryRun = true
+                retryCount = 1
+                retryWaitSec = 1
+                proxy = globalProxy
+            }
         }
 
         then:
@@ -197,63 +200,11 @@ class SshPluginSpec extends Specification {
         proxyNameSet(childProject.proxies) == ['socks', 'http'].toSet()
     }
 
-    def "invoke sshexec"() {
-        given:
-        def project = createProject()
-
-        when:
-        project.with {
-            sshexec {
-                ssh {
-                    dryRun = true
-                    knownHosts = file('my_known_hosts')
-                }
-                session(remotes.webServer) {
-                    execute 'ls'
-                }
-            }
-        }
-
-        then: noExceptionThrown()
-    }
-
-    def "sshexec() returns a result of the closure"() {
-        given:
-        def project = createProject()
-
-        when:
-        project.with {
-            project.ext.actualResult = sshexec {
-                ssh {
-                    dryRun = true
-                }
-                session(remotes.webServer) {
-                    execute 'ls'
-                    'ls-result'
-                }
-            }
-        }
-
-        then: project.ext.actualResult == 'ls-result'
-    }
-
-    def "invoke sshexec with null"() {
-        given:
-        def project = createProject()
-
-        when:
-        project.sshexec(null)
-
-        then:
-        AssertionError err = thrown()
-        err.message.contains("closure")
-    }
-
     private static createProject() {
         ProjectBuilder.builder().build().with {
             apply plugin: 'org.hidetake.ssh'
 
-            ssh {
+            ssh.settings {
                 knownHosts = allowAnyHosts
             }
 

--- a/src/test/groovy/org/hidetake/gradle/ssh/plugin/SshTaskSpec.groovy
+++ b/src/test/groovy/org/hidetake/gradle/ssh/plugin/SshTaskSpec.groovy
@@ -21,7 +21,7 @@ class SshTaskSpec extends Specification {
                     identity = file('id_rsa')
                 }
             }
-            ssh {
+            ssh.settings {
                 dryRun = false
                 proxy = proxies.globalProxy
             }


### PR DESCRIPTION
This pull request removes `sshexec` method support for simple design. The convention object will be replaced with the extension object.
