### PR TITLE
Replace ssh task with ssh.run

### DIFF
--- a/acceptance-test/authentication.gradle
+++ b/acceptance-test/authentication.gradle
@@ -19,33 +19,38 @@ feature('using remote specific identity') {
     category 'aggressiveTest'
 }
 
-task useRemoteSpecificIdentity(type: SshTask) {
+task useRemoteSpecificIdentity {
     dependsOn   'createUserWithAuthorizedKey'
     finalizedBy 'deleteUserWithAuthorizedKey'
-
-    session(remotes.dedicatedIdentity) {
-        ext.whoami = execute('whoami')
-    }
     doLast {
-        assert whoami == remotes.dedicatedIdentity.user
+        assert ssh.run {
+            session(remotes.dedicatedIdentity) {
+                execute('whoami')
+            }
+        } == remotes.dedicatedIdentity.user
     }
 }
 
-task createUserWithAuthorizedKey(type: SshTask) {
+task createUserWithAuthorizedKey {
     finalizedBy 'deleteUserWithAuthorizedKey'
-
-    session(remotes.localhost) {
-        def username = remotes.dedicatedIdentity.user
-        execute("sudo useradd -m $username")
-        execute("sudo -u $username mkdir ~$username/.ssh")
-        execute("sudo -u $username tee ~$username/.ssh/authorized_keys < ~/.ssh/id_rsa_pass.pub")
+    doLast {
+        ssh.run {
+            session(remotes.localhost) {
+                def username = remotes.dedicatedIdentity.user
+                execute("sudo useradd -m $username")
+                execute("sudo -u $username mkdir ~$username/.ssh")
+                execute("sudo -u $username tee ~$username/.ssh/authorized_keys < ~/.ssh/id_rsa_pass.pub")
+            }
+        }
     }
 }
 
-task deleteUserWithAuthorizedKey(type: SshTask) {
-    session(remotes.localhost) {
-        def username = remotes.dedicatedIdentity.user
-        execute("sudo userdel -r $username")
+task deleteUserWithAuthorizedKey << {
+    ssh.run {
+        session(remotes.localhost) {
+            def username = remotes.dedicatedIdentity.user
+            execute("sudo userdel -r $username")
+        }
     }
 }
 
@@ -55,16 +60,14 @@ feature('authenticate with the ssh agent') {
     category 'testWithAgent'
 }
 
-task authenticateWithSshAgent(type: SshTask) {
-    doFirst {
-        ext.x = randomInt()
-        ext.y = randomInt()
+task authenticateWithSshAgent << {
+    def x = randomInt()
+    def y = randomInt()
+    def a = ssh.run {
+        session(remotes.usingAgent) {
+            execute "expr $x + $y"
+        }
     }
-    session(remotes.usingAgent) {
-        ext.a = execute "expr $x + $y"
-    }
-    doLast {
-        assert a as int == (x + y)
-    }
+    assert a as int == (x + y)
 }
 

--- a/acceptance-test/build.gradle
+++ b/acceptance-test/build.gradle
@@ -54,10 +54,12 @@ task cleanLocalTemp << {
     buildDir.mkdir()
 }
 
-task cleanRemoteTemp(type: SshTask) {
-    session(remotes.localhost) {
-        assert remoteTempPrefix
-        execute("rm -vr ${remoteTempPrefix}*")
+task cleanRemoteTemp << {
+    assert remoteTempPrefix
+    ssh.run {
+        session(remotes.localhost) {
+            execute("rm -vr ${remoteTempPrefix}*")
+        }
     }
 }
 

--- a/acceptance-test/command-execution.gradle
+++ b/acceptance-test/command-execution.gradle
@@ -4,17 +4,15 @@ feature('executing a command') {
     category 'test'
 }
 
-task executeCommand(type: SshTask) {
-    doFirst {
-        ext.x = randomInt()
-        ext.y = randomInt()
+task executeCommand << {
+    def x = randomInt()
+    def y = randomInt()
+    def a = ssh.run {
+        session(remotes.localhost) {
+            execute "expr $x + $y"
+        }
     }
-    session(remotes.localhost) {
-        ext.a = execute "expr $x + $y"
-    }
-    doLast {
-        assert a as int == (x + y)
-    }
+    assert a as int == (x + y)
 }
 
 
@@ -23,17 +21,15 @@ feature('execute a command with console logging to stdout') {
     category 'test'
 }
 
-task executeCommandWithLogging(type: SshTask) {
-    doFirst {
-        ext.x = randomInt()
-        ext.y = randomInt()
+task executeCommandWithLogging << {
+    def x = randomInt()
+    def y = randomInt()
+    def a = ssh.run {
+        session(remotes.localhost) {
+            execute "expr $x + $y", logging: 'stdout'
+        }
     }
-    session(remotes.localhost) {
-        ext.a = execute "expr $x + $y", logging: 'stdout'
-    }
-    doLast {
-        assert a as int == (x + y)
-    }
+    assert a as int == (x + y)
 }
 
 
@@ -42,22 +38,23 @@ feature('executing commands sequentially') {
     category 'test'
 }
 
-task executeSequentially(type: SshTask) {
+task executeSequentially {
     finalizedBy 'cleanRemoteTemp'
-
-    doFirst {
-        ext.x = randomInt()
-        ext.y = randomInt()
-        ext.pathA = remoteTempPath('A')
-        ext.pathB = remoteTempPath('B')
-    }
-    session(remotes.localhost) {
-        execute "expr $x + $y > $pathA"
-        execute "expr $x + `cat $pathA` > $pathB"
-        ext.a = execute "cat $pathA"
-        ext.b = execute "cat $pathB"
-    }
     doLast {
+        def x = randomInt()
+        def y = randomInt()
+        def pathA = remoteTempPath('A')
+        def pathB = remoteTempPath('B')
+        def a
+        def b
+        ssh.run {
+            session(remotes.localhost) {
+                execute "expr $x + $y > $pathA"
+                execute "expr $x + `cat $pathA` > $pathB"
+                a = execute "cat $pathA"
+                b = execute "cat $pathB"
+            }
+        }
         assert a as int == (x + y)
         assert b as int == (x + x + y)
     }
@@ -69,14 +66,14 @@ feature('each command should have independent environment') {
     category 'test'
 }
 
-task testEnvironmentOfCommand(type: SshTask) {
-    session(remotes.localhost) {
-        execute "export testdata=dummy"
-        ext.a = execute 'echo "testdata is $testdata"'
+task testEnvironmentOfCommand << {
+    def a = ssh.run {
+        session(remotes.localhost) {
+            execute "export testdata=dummy"
+            execute 'echo "testdata is $testdata"'
+        }
     }
-    doLast {
-        assert a == 'testdata is '
-    }
+    assert a == 'testdata is '
 }
 
 
@@ -85,14 +82,16 @@ feature('executing a command with PTY allocation') {
     category 'test'
 }
 
-task executeCommandWithPty(type: SshTask) {
-    session(remotes.localhost) {
-        executeBackground("env | grep -v SSH_TTY")
-        executeBackground("env | grep SSH_TTY", pty: true)
-    }
-    session(remotes.localhost) {
-        execute("env | grep -v SSH_TTY")
-        execute("env | grep SSH_TTY", pty: true)
+task executeCommandWithPty << {
+    ssh.run {
+        session(remotes.localhost) {
+            executeBackground("env | grep -v SSH_TTY")
+            executeBackground("env | grep SSH_TTY", pty: true)
+        }
+        session(remotes.localhost) {
+            execute("env | grep -v SSH_TTY")
+            execute("env | grep SSH_TTY", pty: true)
+        }
     }
 }
 
@@ -102,22 +101,21 @@ feature('executing commands concurrently') {
     category 'test'
 }
 
-task executeConcurrently(type: SshTask) {
+task executeConcurrently {
     finalizedBy 'cleanRemoteTemp'
-
-    doFirst {
-        ext.tempPath = remoteTempPath(name)
-    }
-    // task should start sessions concurrently
-    session(remotes.localhost) {
-        executeBackground "sleep 2 && echo 2 >> $tempPath"
-    }
-    session(remotes.localhost) {
-        executeBackground "sleep 3 && echo 3 >> $tempPath"
-        executeBackground "sleep 1 && echo 1 >> $tempPath"
-        executeBackground            "echo 0 >> $tempPath"
-    }
     doLast {
+        def tempPath = remoteTempPath(name)
+        ssh.run {
+            // task should start sessions concurrently
+            session(remotes.localhost) {
+                executeBackground "sleep 2 && echo 2 >> $tempPath"
+            }
+            session(remotes.localhost) {
+                executeBackground "sleep 3 && echo 3 >> $tempPath"
+                executeBackground "sleep 1 && echo 1 >> $tempPath"
+                executeBackground "echo 0 >> $tempPath"
+            }
+        }
         // all commands should be completed at this point
         def result = ssh.run {
             session(remotes.localhost) {

--- a/acceptance-test/connect-via-gateways.gradle
+++ b/acceptance-test/connect-via-gateways.gradle
@@ -26,15 +26,13 @@ feature('connect via a gateway host') {
     category 'test'
 }
 
-task connectViaGateway(type: SshTask) {
-    doFirst {
-        ext.x = randomInt()
-        ext.y = randomInt()
+task connectViaGateway << {
+    def x = randomInt()
+    def y = randomInt()
+    def a = ssh.run {
+        session(remotes.viaGateway) {
+            execute "expr $x + $y"
+        }
     }
-    session(remotes.viaGateway) {
-        ext.a = execute "expr $x + $y"
-    }
-    doLast {
-        assert a as int == (x + y)
-    }
+    assert a as int == (x + y)
 }

--- a/acceptance-test/dsl-extension.gradle
+++ b/acceptance-test/dsl-extension.gradle
@@ -10,16 +10,16 @@ class RemoteFileAssertion {
     }
 }
 
-task extendRemoteFileAssertion(type: SshTask) {
-    ssh {
-        extensions.add RemoteFileAssertion
-    }
-    doFirst {
-        ext.x = randomInt()
-        ext.pathX = remoteTempPath('X')
-    }
-    session(remotes.localhost) {
-        execute "echo 'port $x' > $pathX"
-        assertFileContains pathX, "port $x"
+task extendRemoteFileAssertion << {
+    def x = randomInt()
+    def pathX = remoteTempPath('X')
+    ssh.run {
+        settings {
+            extensions.add RemoteFileAssertion
+        }
+        session(remotes.localhost) {
+            execute "echo 'port $x' > $pathX"
+            assertFileContains pathX, "port $x"
+        }
     }
 }

--- a/acceptance-test/file-transfer.gradle
+++ b/acceptance-test/file-transfer.gradle
@@ -143,24 +143,27 @@ feature('retrieve a large file from the remote host and send it again') {
     category 'aggressiveTest'
 }
 
-task getAndPutLargeFile(type: SshTask, dependsOn: 'setupBuildDir') {
+task getAndPutLargeFile {
+    dependsOn 'setupBuildDir'
     finalizedBy 'cleanLocalTemp'
     finalizedBy 'cleanRemoteTemp'
 
-    doFirst {
-        ext.sizeX = 1024 * 256
-        ext.localX = file("$buildDir/local-${randomInt()}")
-        ext.pathX = remoteTempPath('X')
-        ext.pathY = remoteTempPath('Y')
-    }
-    session(remotes.localhost) {
-        execute("dd if=/dev/zero of=$pathX bs=1024 count=$sizeX")
-        get pathX, localX
-
-        put localX, pathY
-        ext.sizeY = execute("wc -c < $pathY") as int
-    }
     doLast {
+        def sizeX = 1024 * 256
+        def localX = file("$buildDir/local-${randomInt()}")
+        def pathX = remoteTempPath('X')
+        def pathY = remoteTempPath('Y')
+
+        def sizeY = ssh.run {
+            session(remotes.localhost) {
+                execute("dd if=/dev/zero of=$pathX bs=1024 count=$sizeX")
+                get pathX, localX
+
+                put localX, pathY
+                execute("wc -c < $pathY") as int
+            }
+        }
+
         assert localX.size() == 1024 * sizeX
         assert sizeY == 1024 * sizeX
     }

--- a/acceptance-test/shell-execution.gradle
+++ b/acceptance-test/shell-execution.gradle
@@ -4,13 +4,15 @@ feature('executing a shell') {
     category 'test'
 }
 
-task executeShell(type: SshTask) {
-    session(remotes.localhost) {
-        shell(interaction: {
-            when(partial: ~/.*[$%#] */) {
-                standardInput << 'exit 0' << '\n'
-            }
-        })
+task executeShell << {
+    ssh.run {
+        session(remotes.localhost) {
+            shell(interaction: {
+                when(partial: ~/.*[$%#] */) {
+                    standardInput << 'exit 0' << '\n'
+                }
+            })
+        }
     }
 }
 

--- a/acceptance-test/sudo-execution.gradle
+++ b/acceptance-test/sudo-execution.gradle
@@ -18,42 +18,47 @@ feature('executing a privileged command by sudo') {
     category 'aggressiveTest'
 }
 
-task executeSudoWithPassword(type: SshTask) {
+task executeSudoWithPassword {
     dependsOn   'createUserForSudoWithPassword'
     finalizedBy 'deleteUserForSudoWithPassword'
-
-    session(remotes.sudoWithPassword) {
-        ext.whoami = executeSudo('whoami', pty: true)
-    }
     doLast {
-        assert whoami == 'root'
-    }
-}
-
-task createUserForSudoWithPassword(type: SshTask) {
-    finalizedBy 'deleteUserForSudoWithPassword'
-
-    session(remotes.localhost) {
-        def username = remotes.sudoWithPassword.user
-        def password = remotes.sudoWithPassword.password
-        execute("sudo useradd -m $username")
-        execute("sudo passwd $username", interaction: {
-            when(partial: ~/.+[Pp]assword: */) {
-                standardInput << password << '\n'
+        assert ssh.run {
+            session(remotes.sudoWithPassword) {
+                executeSudo('whoami', pty: true)
             }
-        })
-        execute("echo '$username ALL=(ALL) ALL' > /tmp/$username")
-        execute("sudo chmod 440 /tmp/$username")
-        execute("sudo chown 0.0 /tmp/$username")
-        execute("sudo mv /tmp/$username /etc/sudoers.d")
+        } == 'root'
     }
 }
 
-task deleteUserForSudoWithPassword(type: SshTask) {
-    session(remotes.localhost) {
-        def username = remotes.sudoWithPassword.user
-        execute("sudo rm -v /etc/sudoers.d/$username")
-        execute("sudo userdel -r $username")
+task createUserForSudoWithPassword {
+    finalizedBy 'deleteUserForSudoWithPassword'
+    doLast {
+        ssh.run {
+            session(remotes.localhost) {
+                def username = remotes.sudoWithPassword.user
+                def password = remotes.sudoWithPassword.password
+                execute("sudo useradd -m $username")
+                execute("sudo passwd $username", interaction: {
+                    when(partial: ~/.+[Pp]assword: */) {
+                        standardInput << password << '\n'
+                    }
+                })
+                execute("echo '$username ALL=(ALL) ALL' > /tmp/$username")
+                execute("sudo chmod 440 /tmp/$username")
+                execute("sudo chown 0.0 /tmp/$username")
+                execute("sudo mv /tmp/$username /etc/sudoers.d")
+            }
+        }
+    }
+}
+
+task deleteUserForSudoWithPassword << {
+    ssh.run {
+        session(remotes.localhost) {
+            def username = remotes.sudoWithPassword.user
+            execute("sudo rm -v /etc/sudoers.d/$username")
+            execute("sudo userdel -r $username")
+        }
     }
 }
 
@@ -63,49 +68,54 @@ feature('executing a command as another user by sudo') {
     category 'aggressiveTest'
 }
 
-task executeSudoAsUserWithPassword(type: SshTask) {
+task executeSudoAsUserWithPassword {
     dependsOn   'createUserForSudoAsUserWithPassword'
     finalizedBy 'deleteUserForSudoAsUserWithPassword'
-
-    def anotherUsername = "${remotes.sudoWithPassword.user}ya"
-    session(remotes.sudoWithPassword) {
-        ext.whoami = executeSudo("-u $anotherUsername whoami", pty: true)
-    }
     doLast {
-        assert whoami == anotherUsername
-    }
-}
-
-task createUserForSudoAsUserWithPassword(type: SshTask) {
-    finalizedBy 'deleteUserForSudoAsUserWithPassword'
-
-    session(remotes.localhost) {
-        def username = remotes.sudoWithPassword.user
-        def password = remotes.sudoWithPassword.password
-        execute("sudo useradd -m $username")
-        execute("sudo passwd $username", interaction: {
-            when(partial: ~/.+[Pp]assword: */) {
-                standardInput << password << '\n'
+        def anotherUsername = "${remotes.sudoWithPassword.user}ya"
+        assert ssh.run {
+            session(remotes.sudoWithPassword) {
+                ext.whoami = executeSudo("-u $anotherUsername whoami", pty: true)
             }
-        })
-        execute("echo '$username ALL=(ALL) ALL' > /tmp/$username")
-        execute("sudo chmod 440 /tmp/$username")
-        execute("sudo chown 0.0 /tmp/$username")
-        execute("sudo mv /tmp/$username /etc/sudoers.d")
-
-        def anotherUsername = "${remotes.sudoWithPassword.user}ya"
-        execute("sudo useradd -m $anotherUsername")
+        } == anotherUsername
     }
 }
 
-task deleteUserForSudoAsUserWithPassword(type: SshTask) {
-    session(remotes.localhost) {
-        def username = remotes.sudoWithPassword.user
-        execute("sudo rm -v /etc/sudoers.d/$username")
-        execute("sudo userdel -r $username")
+task createUserForSudoAsUserWithPassword {
+    finalizedBy 'deleteUserForSudoAsUserWithPassword'
+    doLast {
+        ssh.run {
+            session(remotes.localhost) {
+                def username = remotes.sudoWithPassword.user
+                def password = remotes.sudoWithPassword.password
+                execute("sudo useradd -m $username")
+                execute("sudo passwd $username", interaction: {
+                    when(partial: ~/.+[Pp]assword: */) {
+                        standardInput << password << '\n'
+                    }
+                })
+                execute("echo '$username ALL=(ALL) ALL' > /tmp/$username")
+                execute("sudo chmod 440 /tmp/$username")
+                execute("sudo chown 0.0 /tmp/$username")
+                execute("sudo mv /tmp/$username /etc/sudoers.d")
 
-        def anotherUsername = "${remotes.sudoWithPassword.user}ya"
-        execute("sudo userdel -r $anotherUsername")
+                def anotherUsername = "${remotes.sudoWithPassword.user}ya"
+                execute("sudo useradd -m $anotherUsername")
+            }
+        }
+    }
+}
+
+task deleteUserForSudoAsUserWithPassword << {
+    ssh.run {
+        session(remotes.localhost) {
+            def username = remotes.sudoWithPassword.user
+            execute("sudo rm -v /etc/sudoers.d/$username")
+            execute("sudo userdel -r $username")
+
+            def anotherUsername = "${remotes.sudoWithPassword.user}ya"
+            execute("sudo userdel -r $anotherUsername")
+        }
     }
 }
 
@@ -115,41 +125,46 @@ feature('executing a privileged command by sudo without password') {
     category 'aggressiveTest'
 }
 
-task executeSudoNoPassword(type: SshTask) {
+task executeSudoNoPassword {
     dependsOn 'createUserForSudoNoPassword'
     finalizedBy 'deleteUserForSudoNoPassword'
-
-    session(remotes.localhost) {
-        ext.whoami = executeSudo('whoami', pty: true)
-    }
     doLast {
-        assert whoami == 'root'
-    }
-}
-
-task createUserForSudoNoPassword(type: SshTask) {
-    finalizedBy 'deleteUserForSudoNoPassword'
-
-    session(remotes.localhost) {
-        def username = remotes.sudoNoPassword.user
-        def password = remotes.sudoNoPassword.password
-        execute("sudo useradd -m $username")
-        execute("sudo passwd $username", interaction: {
-            when(partial: ~/.+[Pp]assword: */) {
-                standardInput << password << '\n'
+        assert ssh.run {
+            session(remotes.localhost) {
+                executeSudo('whoami', pty: true)
             }
-        })
-        execute("echo '$username ALL=(ALL) NOPASSWD: ALL' > /tmp/$username")
-        execute("sudo chmod 440 /tmp/$username")
-        execute("sudo chown 0.0 /tmp/$username")
-        execute("sudo mv /tmp/$username /etc/sudoers.d")
+        } == 'root'
     }
 }
 
-task deleteUserForSudoNoPassword(type: SshTask) {
-    session(remotes.localhost) {
-        def username = remotes.sudoNoPassword.user
-        execute("sudo rm -v /etc/sudoers.d/$username")
-        execute("sudo userdel -r $username")
+task createUserForSudoNoPassword {
+    finalizedBy 'deleteUserForSudoNoPassword'
+    doLast {
+        ssh.run {
+            session(remotes.localhost) {
+                def username = remotes.sudoNoPassword.user
+                def password = remotes.sudoNoPassword.password
+                execute("sudo useradd -m $username")
+                execute("sudo passwd $username", interaction: {
+                    when(partial: ~/.+[Pp]assword: */) {
+                        standardInput << password << '\n'
+                    }
+                })
+                execute("echo '$username ALL=(ALL) NOPASSWD: ALL' > /tmp/$username")
+                execute("sudo chmod 440 /tmp/$username")
+                execute("sudo chown 0.0 /tmp/$username")
+                execute("sudo mv /tmp/$username /etc/sudoers.d")
+            }
+        }
+    }
+}
+
+task deleteUserForSudoNoPassword << {
+    ssh.run {
+        session(remotes.localhost) {
+            def username = remotes.sudoNoPassword.user
+            execute("sudo rm -v /etc/sudoers.d/$username")
+            execute("sudo userdel -r $username")
+        }
     }
 }


### PR DESCRIPTION
This pull request replaces deprecated `SshTask` with `ssh.run` syntax.

`SshTask` will be no longer supported in the future release.