### PR TITLE
Change default logging method to stdout

### DIFF
--- a/acceptance-test/command-execution.gradle
+++ b/acceptance-test/command-execution.gradle
@@ -9,12 +9,12 @@ task('feature: execute a command') << {
     } as int == (x + y)
 }
 
-task('feature: execute a command with console logging to stdout') << {
+task('feature: execute a command with console logging to slf4j') << {
     def x = randomInt()
     def y = randomInt()
     assert ssh.run {
         session(remotes.localhost) {
-            execute "expr $x + $y", logging: 'stdout'
+            execute "expr $x + $y", logging: 'slf4j'
         }
     } as int == (x + y)
 }

--- a/src/main/groovy/org/hidetake/gradle/ssh/plugin/SshPlugin.groovy
+++ b/src/main/groovy/org/hidetake/gradle/ssh/plugin/SshPlugin.groovy
@@ -7,6 +7,7 @@ import org.gradle.api.Project
 import org.hidetake.groovy.ssh.Ssh
 import org.hidetake.groovy.ssh.core.Proxy
 import org.hidetake.groovy.ssh.core.Remote
+import org.hidetake.groovy.ssh.core.settings.OperationSettings
 
 /**
  * Main class of Gradle SSH plugin.
@@ -20,6 +21,8 @@ class SshPlugin implements Plugin<Project> {
         project.extensions.ssh = Ssh.newService()
         project.extensions.remotes = createRemoteContainer(project)
         project.extensions.proxies = createProxyContainer(project)
+
+        project.ssh.settings.logging = OperationSettings.Logging.stdout
 
         // TODO: remove in future release
         project.ext.SshTask = SshTask

--- a/src/test/groovy/org/hidetake/gradle/ssh/plugin/SshPluginSpec.groovy
+++ b/src/test/groovy/org/hidetake/gradle/ssh/plugin/SshPluginSpec.groovy
@@ -5,6 +5,7 @@ import org.hidetake.groovy.ssh.core.Proxy
 import org.hidetake.groovy.ssh.core.Remote
 import org.hidetake.groovy.ssh.core.settings.CompositeSettings
 import org.hidetake.groovy.ssh.core.settings.ConnectionSettings
+import org.hidetake.groovy.ssh.core.settings.OperationSettings
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -19,6 +20,7 @@ class SshPluginSpec extends Specification {
 
         then:
         project.ssh.settings instanceof CompositeSettings
+        project.ssh.settings.logging == OperationSettings.Logging.stdout
         project.remotes.size() == 0
         project.proxies.size() == 0
         project.SshTask == SshTask
@@ -37,6 +39,7 @@ class SshPluginSpec extends Specification {
                 dryRun = true
                 retryCount = 1
                 retryWaitSec = 1
+                logging = 'slf4j'
                 proxy = globalProxy
             }
         }
@@ -45,6 +48,7 @@ class SshPluginSpec extends Specification {
         project.ssh.settings.dryRun
         project.ssh.settings.retryCount == 1
         project.ssh.settings.retryWaitSec == 1
+        project.ssh.settings.logging == OperationSettings.Logging.slf4j
         project.ssh.settings.proxy == globalProxy
     }
 


### PR DESCRIPTION
This pull request changes default logging method to `stdout` and makes easy to find problems.