### PR TITLE
Give access to the project from an extension code

### DIFF
--- a/acceptance-test/dsl-extension.gradle
+++ b/acceptance-test/dsl-extension.gradle
@@ -1,10 +1,10 @@
 
 final runOnGradle2 = { GradleVersion.current().version.startsWith('2.') }
 
-task('should extends DSL with the remote file extension') { onlyIf runOnGradle2 } << {
+task('should apply the remote file extension') { onlyIf runOnGradle2 } << {
     ssh.run {
         settings {
-            extensions = [RemoteFileExtension]
+            extensions << RemoteFileExtension
         }
         session(remotes.localhost) {
             execute "mkdir -vp $remoteWorkDir"
@@ -30,13 +30,10 @@ dependencies {
     groovyRuntime 'org.codehaus.groovy:groovy-all:2.3.9'
 }
 
-task('should extends DSL with the extension which accesses to the project') { onlyIf runOnGradle2 } << {
-    // workaround to give access
-    ProjectLocator.project = project
-
+task('should apply the extension which accesses to the project') { onlyIf runOnGradle2 } << {
     assert ssh.run {
         settings {
-            extensions = [ScriptExtension, ProjectInjection]
+            extensions << ScriptExtension
         }
         session(remotes.localhost) {
             executeGroovyScript 'println GroovySystem.version'

--- a/src/main/groovy/org/hidetake/gradle/ssh/plugin/ProjectInjection.groovy
+++ b/src/main/groovy/org/hidetake/gradle/ssh/plugin/ProjectInjection.groovy
@@ -1,0 +1,25 @@
+package org.hidetake.gradle.ssh.plugin
+
+import org.gradle.api.Project
+
+/**
+ * An extension to provide access to the {@link Project}.
+ *
+ * @author Hidetake Iwata
+ */
+trait ProjectInjection {
+
+    static class Locator {
+        protected static Project project
+    }
+
+    /**
+     * Return the project.
+     *
+     * @return the project
+     */
+    Project getProject() {
+        Locator.project
+    }
+
+}

--- a/src/main/groovy/org/hidetake/gradle/ssh/plugin/SshPlugin.groovy
+++ b/src/main/groovy/org/hidetake/gradle/ssh/plugin/SshPlugin.groovy
@@ -7,7 +7,6 @@ import org.gradle.api.Project
 import org.hidetake.groovy.ssh.Ssh
 import org.hidetake.groovy.ssh.core.Proxy
 import org.hidetake.groovy.ssh.core.Remote
-import org.hidetake.groovy.ssh.core.settings.OperationSettings
 
 /**
  * Main class of Gradle SSH plugin.
@@ -23,6 +22,11 @@ class SshPlugin implements Plugin<Project> {
         project.extensions.proxies = createProxyContainer(project)
 
         project.ssh.settings.logging = 'stdout'
+
+        if (GroovySystem.version >= '2.3') {
+            ProjectInjection.Locator.project = project
+            project.ssh.settings.extensions << ProjectInjection
+        }
 
         // TODO: remove in future release
         project.ext.SshTask = SshTask

--- a/src/test/groovy/org/hidetake/gradle/ssh/plugin/ExampleExtension.groovy
+++ b/src/test/groovy/org/hidetake/gradle/ssh/plugin/ExampleExtension.groovy
@@ -1,0 +1,10 @@
+package org.hidetake.gradle.ssh.plugin
+
+trait ExampleExtension {
+
+    def example() {
+        execute 'ls'
+        project.name
+    }
+
+}

--- a/src/test/groovy/org/hidetake/gradle/ssh/plugin/ExtensionSpec.groovy
+++ b/src/test/groovy/org/hidetake/gradle/ssh/plugin/ExtensionSpec.groovy
@@ -1,0 +1,47 @@
+package org.hidetake.gradle.ssh.plugin
+
+import org.gradle.api.Project
+import org.gradle.testfixtures.ProjectBuilder
+import spock.lang.Specification
+
+class ExtensionSpec extends Specification {
+
+    Project project
+
+    def setup() {
+        project = ProjectBuilder.builder().withName('extensionSpec').build()
+        project.with {
+            apply plugin: 'org.hidetake.ssh'
+            ssh.settings {
+                dryRun = true
+                extensions << ExampleExtension
+            }
+            remotes {
+                testServer {
+                    host = 'localhost'
+                    user = 'user'
+                }
+            }
+        }
+    }
+
+    def "extension should be able to access to the project"() {
+        given:
+        project.with {
+            task('testTask') << {
+                project.ext.result = ssh.run {
+                    session(remotes.testServer) {
+                        example()
+                    }
+                }
+            }
+        }
+
+        when:
+        project.tasks.testTask.execute()
+
+        then:
+        project.result == 'extensionSpec'
+    }
+
+}


### PR DESCRIPTION
This pull request give access to the project from an extension code.

e.g.

```groovy
trait ExampleExtension {
  def example() {
    project.name
  }
}

// code in some task
ssh.run {
  ssh.settings {
    extensions << ExampleExtension
  }
  session(remotes.testServer) {
    example()
  }
}
```