### PR TITLE
Gradle 2.3

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,4 +1,4 @@
-#Sun Feb 22 14:25:03 JST 2015
+#Thu Mar 05 04:29:23 UTC 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
[Gradle 2.3](https://gradle.org/docs/2.3/release-notes) is available now.

This pull request updates Gradle wrapper and build.gradle in the repository.
Please merge this if all tests are passed on the new Gradle.