### PR TITLE
Add ssh.version property

### DIFF
--- a/acceptance-test/spec/Version.gradle
+++ b/acceptance-test/spec/Version.gradle
@@ -1,0 +1,4 @@
+task('should show version of the plugin') << {
+    println ssh.version
+    assert ssh.version instanceof String
+}

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,10 @@ dependencies {
     testCompile 'cglib:cglib-nodep:3.1'
 }
 
+processResources {
+    filter(org.apache.tools.ant.filters.ReplaceTokens, tokens: ['version': project.version])
+}
+
 task javadocJar(type: Jar, dependsOn: groovydoc) {
     from "${buildDir}/docs/groovydoc"
     classifier = 'javadoc'

--- a/src/main/groovy/org/hidetake/gradle/ssh/plugin/SshPlugin.groovy
+++ b/src/main/groovy/org/hidetake/gradle/ssh/plugin/SshPlugin.groovy
@@ -22,6 +22,8 @@ class SshPlugin implements Plugin<Project> {
         project.extensions.proxies = createProxyContainer(project)
 
         project.ssh.settings.logging = 'stdout'
+
+        project.ssh.metaClass.mixin(VersionExtension)
     }
 
     private static createRemoteContainer(Project project) {

--- a/src/main/groovy/org/hidetake/gradle/ssh/plugin/VersionExtension.groovy
+++ b/src/main/groovy/org/hidetake/gradle/ssh/plugin/VersionExtension.groovy
@@ -1,0 +1,28 @@
+package org.hidetake.gradle.ssh.plugin
+
+import org.hidetake.groovy.ssh.Ssh
+
+/**
+ * An extension class for {@code project.ssh} instance.
+ *
+ * @author Hidetake Iwata
+ */
+class VersionExtension {
+
+    @Lazy
+    String version = {
+        def resourcePath = '/META-INF/gradle-plugins/org.hidetake.ssh.properties'
+        VersionExtension.getResourceAsStream(resourcePath)?.withStream { stream ->
+            def properties = new Properties()
+            properties.load(stream)
+            def name = properties.getProperty('product.name')
+            def version = properties.getProperty('product.version')
+            "$name-$version (" +
+                    "groovy-ssh-${Ssh.release.version}, " +
+                    "jsch-${Ssh.release.jschVersion}, " +
+                    "groovy-${Ssh.release.groovyVersion}, " +
+                    "java-${Ssh.release.javaVersion})"
+        }
+    }()
+
+}

--- a/src/main/resources/META-INF/gradle-plugins/org.hidetake.ssh.properties
+++ b/src/main/resources/META-INF/gradle-plugins/org.hidetake.ssh.properties
@@ -1,1 +1,3 @@
 implementation-class=org.hidetake.gradle.ssh.plugin.SshPlugin
+product.name=gradle-ssh-plugin
+product.version=@version@

--- a/src/test/groovy/org/hidetake/gradle/ssh/plugin/SshPluginSpec.groovy
+++ b/src/test/groovy/org/hidetake/gradle/ssh/plugin/SshPluginSpec.groovy
@@ -11,6 +11,17 @@ import spock.lang.Unroll
 
 class SshPluginSpec extends Specification {
 
+    def "ssh.version should return release version"() {
+        given:
+        def project = ProjectBuilder.builder().build()
+
+        when:
+        project.apply plugin: 'org.hidetake.ssh'
+
+        then:
+        project.ssh.version instanceof String
+    }
+
     def "default settings should be set"() {
         given:
         def project = ProjectBuilder.builder().build()


### PR DESCRIPTION
This adds `ssh.version` property for easy inspection of dependencies.