### PR TITLE
Add property of target Gradle versions on acceptance test

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,14 @@ Prerequisite:
 Run `test` task.
 
 ```sh
-./gradlew :acceptance-tests:test
+EXT_SSH_HOST=... EXT_SSH_USER=... ./gradlew :acceptance-tests:test
+```
+
+It runs on the current version and 1.12 of Gradle at default.
+Target versions can be given by `target.gradle.versions` property as follows:
+
+```sh
+./gradlew -Ptarget.gradle.versions=3.0,2.0,1.12 :acceptance-tests:test
 ```
 
 #### Release

--- a/acceptance-test/build.gradle
+++ b/acceptance-test/build.gradle
@@ -15,7 +15,7 @@ dependencies {
 
 test {
     dependsOn ':publishToMavenLocal'
-    testLogging {
-        showStandardStreams = true
-    }
+    testLogging.showStandardStreams = true
+    systemProperty 'target.gradle.versions',
+            project.findProperty('target.gradle.versions') ?: "${gradle.gradleVersion},1.12"
 }

--- a/acceptance-test/src/test/groovy/org/hidetake/gradle/ssh/plugin/AcceptanceSpec.groovy
+++ b/acceptance-test/src/test/groovy/org/hidetake/gradle/ssh/plugin/AcceptanceSpec.groovy
@@ -8,18 +8,25 @@ class AcceptanceSpec extends Specification {
 
     @Unroll
     def "acceptance test should be success on Gradle #version"() {
-        when:
-        GradleRunner.create()
+        given:
+        def runner = GradleRunner.create()
                 .withProjectDir(new File('fixture'))
                 .withArguments('test')
                 .withGradleVersion(version)
-                .build()
+
+        and: 'show console on Gradle 2.x'
+        if (version =~ /^2\./) {
+            runner.forwardOutput()
+        }
+
+        when:
+        runner.build()
 
         then:
         noExceptionThrown()
 
         where:
-        version << ['2.13', '1.12']
+        version << System.getProperty('target.gradle.versions').split(/,/).toList()
     }
 
 }


### PR DESCRIPTION
This adds the property `target.gradle.versions` to specify Gradle versions for acceptance test. Groovy SSH can reduce CI time.