### PR TITLE
Target JVM can be given on acceptance test

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,15 @@ The document is maintained on the repository of Groovy SSH.
 We can run acceptance tests to verify behavior of the plugin on Gradle environment.
 It expects a SSH server is running at localhost port 8022.
 
-It runs on the current version and 1.12 of Gradle at default.
-Target versions can be given by `target.gradle.versions` property as follows:
+At default, it runs on the current version and 1.12 of Gradle, and the default JVM.
+Test condition can be set by system properties as follows:
+
+System Property             | Value
+----------------------------|------
+`target.gradle.versions`    | List of target Gradle version
+`target.java.homes`         | List of target JVM
+
+e.g.
 
 ```sh
 ./gradlew -Ptarget.gradle.versions=3.0,2.0,1.12 :acceptance-tests:test

--- a/acceptance-test/build.gradle
+++ b/acceptance-test/build.gradle
@@ -15,6 +15,8 @@ dependencies {
 
 test {
     dependsOn ':core:publishToMavenLocal'
+    systemProperty 'target.java.homes',
+            project.findProperty('target.java.homes') ?: System.getProperty('java.home')
     systemProperty 'target.gradle.versions',
             project.findProperty('target.gradle.versions') ?: "${gradle.gradleVersion},1.12"
 }

--- a/acceptance-test/src/test/groovy/org/hidetake/gradle/ssh/plugin/AcceptanceSpec.groovy
+++ b/acceptance-test/src/test/groovy/org/hidetake/gradle/ssh/plugin/AcceptanceSpec.groovy
@@ -6,21 +6,27 @@ import spock.lang.Unroll
 
 class AcceptanceSpec extends Specification {
 
+    static final matrix = []
+    static {
+        System.getProperty('target.gradle.versions').split(/,/).collect { gradleVersion ->
+            System.getProperty('target.java.homes').split(/,/).collect { javaHome ->
+                matrix << [gradleVersion, javaHome]
+            }
+        }
+    }
+
     @Unroll
-    def "acceptance test should be success on Gradle #version"() {
+    def "specs should be pass on Gradle #gradleVersion, Java #javaHome"() {
         given:
         def runner = GradleRunner.create()
                 .withProjectDir(new File('fixture'))
-                .withArguments('test')
-                .withGradleVersion(version)
+                .withArguments("-Dorg.gradle.java.home=$javaHome", 'test')
+                .withGradleVersion(gradleVersion)
 
         and: 'show console on Gradle 2.x'
-        if (version =~ /^2\./) {
+        if (gradleVersion =~ /^2\./) {
             runner.forwardOutput()
         }
-
-        and: 'show system properties'
-        System.properties.each { k, v -> println("$k = $v") }
 
         when:
         runner.build()
@@ -29,7 +35,7 @@ class AcceptanceSpec extends Specification {
         noExceptionThrown()
 
         where:
-        version << System.getProperty('target.gradle.versions').split(/,/).toList()
+        [gradleVersion, javaHome] << matrix
     }
 
 }


### PR DESCRIPTION
This adds feature to specify target JVM on acceptance test for verifying compatibility.