### PR TITLE
Replace deprecated left shift (<<) operator on Task interface

### DIFF
--- a/acceptance-test/fixture/build.gradle
+++ b/acceptance-test/fixture/build.gradle
@@ -28,25 +28,29 @@ remotes {
 ext.localWorkDirBase = file("$buildDir/tmp")
 ext.remoteWorkDirBase = '/tmp/gradle-ssh-plugin.acceptance-test'
 
-task setup << {
-    println "Gradle: ${gradle.gradleVersion}"
-    println "Java: ${System.getProperty('java.home')}"
-    println "Target: ${ssh.version}"
-    delete localWorkDirBase
-    localWorkDirBase.mkdirs()
-    ssh.run {
-        session(remotes.testServer) {
-            remove remoteWorkDirBase
-            execute "mkdir -vp $remoteWorkDirBase"
+task setup {
+    doLast {
+        println "Gradle: ${gradle.gradleVersion}"
+        println "Java: ${System.getProperty('java.home')}"
+        println "Target: ${ssh.version}"
+        delete localWorkDirBase
+        localWorkDirBase.mkdirs()
+        ssh.run {
+            session(remotes.testServer) {
+                remove remoteWorkDirBase
+                execute "mkdir -vp $remoteWorkDirBase"
+            }
         }
     }
 }
 
-task cleanup << {
-    delete localWorkDirBase
-    ssh.run {
-        session(remotes.testServer) {
-            remove remoteWorkDirBase
+task cleanup {
+    doLast {
+        delete localWorkDirBase
+        ssh.run {
+            session(remotes.testServer) {
+                remove remoteWorkDirBase
+            }
         }
     }
 }

--- a/acceptance-test/fixture/spec/CommandSpec.gradle
+++ b/acceptance-test/fixture/spec/CommandSpec.gradle
@@ -1,100 +1,116 @@
 
-task('should execute the command') << {
-    def x = randomInt()
-    def y = randomInt()
-    assert ssh.run {
-        session(remotes.testServer) {
-            execute "expr $x + $y"
-        }
-    } as int == (x + y)
+task('should execute the command') {
+    doLast {
+        def x = randomInt()
+        def y = randomInt()
+        assert ssh.run {
+            session(remotes.testServer) {
+                execute "expr $x + $y"
+            }
+        } as int == (x + y)
+    }
 }
 
-task('should execute the command with console logging with slf4j') << {
-    def x = randomInt()
-    def y = randomInt()
-    assert ssh.run {
-        session(remotes.testServer) {
-            execute "expr $x + $y", logging: 'slf4j'
-        }
-    } as int == (x + y)
+task('should execute the command with console logging with slf4j') {
+    doLast {
+        def x = randomInt()
+        def y = randomInt()
+        assert ssh.run {
+            session(remotes.testServer) {
+                execute "expr $x + $y", logging: 'slf4j'
+            }
+        } as int == (x + y)
+    }
 }
 
-task('should execute commands by multi-line string') << {
-    def x = randomInt()
-    def y = randomInt()
+task('should execute commands by multi-line string') {
     def a
     def b
-    ssh.run {
-        session(remotes.testServer) {
-            execute """
-mkdir -vp $remoteWorkDir
-expr $x + $y > $remoteWorkDir/A
-expr $x + `cat $remoteWorkDir/A` > $remoteWorkDir/B
-"""
-            a = get from: "$remoteWorkDir/A"
-            b = get from: "$remoteWorkDir/B"
-        }
-    }
-    assert a as int == (x + y)
-    assert b as int == (x + x + y)
-}
-
-task('should execute the command with the PTY allocation') << {
-    ssh.run {
-        session(remotes.testServer) {
-            execute "env | grep -v SSH_TTY"
-            execute "env | grep SSH_TTY", pty: true
-        }
-    }
-}
-
-task('should throw an exception due to the error exit status') << {
-    try {
+    doLast {
+        def x = randomInt()
+        def y = randomInt()
         ssh.run {
             session(remotes.testServer) {
-                execute 'exit 1'
+                execute """
+                mkdir -vp $remoteWorkDir
+                expr $x + $y > $remoteWorkDir/A
+                expr $x + `cat $remoteWorkDir/A` > $remoteWorkDir/B
+                """
+                a = get from: "$remoteWorkDir/A"
+                b = get from: "$remoteWorkDir/B"
             }
         }
-        assert false, 'an exception should be thrown'
-    } catch(RuntimeException e) {
-        assert e.localizedMessage.contains('status 1')
+        assert a as int == (x + y)
+        assert b as int == (x + x + y)
     }
 }
 
-task('should write output of the command to the file') << {
-    def x = randomInt()
-    def y = randomInt()
-    localWorkDir.mkdirs()
-    def resultFile = file("$localWorkDir/result")
-    resultFile.withOutputStream { stream ->
+task('should execute the command with the PTY allocation') {
+    doLast {
         ssh.run {
             session(remotes.testServer) {
-                execute "expr $x + $y", outputStream: stream
+                execute "env | grep -v SSH_TTY"
+                execute "env | grep SSH_TTY", pty: true
             }
         }
     }
-    assert resultFile.text as int == (x + y)
 }
 
-task('should write output of the command to the standard output') << {
-    def x = randomInt()
-    def y = randomInt()
-    ssh.run {
-        session(remotes.testServer) {
-            execute "expr $x + $y", outputStream: System.out
+task('should throw an exception due to the error exit status') {
+    doLast {
+        try {
+            ssh.run {
+                session(remotes.testServer) {
+                    execute 'exit 1'
+                }
+            }
+            assert false, 'an exception should be thrown'
+        } catch(RuntimeException e) {
+            assert e.localizedMessage.contains('status 1')
         }
     }
 }
 
-task('should write error of the command to the file') << {
-    localWorkDir.mkdirs()
-    def resultFile = file("$localWorkDir/result")
-    resultFile.withOutputStream { stream ->
+task('should write output of the command to the file') {
+    doLast {
+        def x = randomInt()
+        def y = randomInt()
+        localWorkDir.mkdirs()
+        def resultFile = file("$localWorkDir/result")
+        resultFile.withOutputStream { stream ->
+            ssh.run {
+                session(remotes.testServer) {
+                    execute "expr $x + $y", outputStream: stream
+                }
+            }
+        }
+        assert resultFile.text as int == (x + y)
+    }
+}
+
+task('should write output of the command to the standard output') {
+    doLast {
+        def x = randomInt()
+        def y = randomInt()
         ssh.run {
             session(remotes.testServer) {
-                execute "cat hoge", ignoreError: true, errorStream: stream
+                execute "expr $x + $y", outputStream: System.out
             }
         }
     }
-    assert resultFile.text.contains('hoge')
+}
+
+task('should write error of the command to the file') {
+    doLast {
+        localWorkDir.mkdirs()
+        def resultFile = file("$localWorkDir/result")
+        resultFile.withOutputStream { stream ->
+            ssh.run {
+                session(remotes.testServer) {
+                    execute "cat hoge", ignoreError: true, errorStream: stream
+                }
+            }
+        }
+        assert resultFile.text.contains('hoge')
+    }
 }

--- a/acceptance-test/fixture/spec/ExtensionSpec.gradle
+++ b/acceptance-test/fixture/spec/ExtensionSpec.gradle
@@ -1,21 +1,23 @@
 
-task('should apply the remote file extension') << {
-    ssh.run {
-        settings {
-            extensions.add eachFile: { String directory, Closure closure ->
-                sftp {
-                    ls(directory).each(closure)
+task('should apply the remote file extension') {
+    doLast {
+        ssh.run {
+            settings {
+                extensions.add eachFile: { String directory, Closure closure ->
+                    sftp {
+                        ls(directory).each(closure)
+                    }
                 }
             }
-        }
-        session(remotes.testServer) {
-            execute "mkdir -vp $remoteWorkDir"
-            put text: 1, into: "$remoteWorkDir/a"
-            put text: 2, into: "$remoteWorkDir/b"
-            put text: 3, into: "$remoteWorkDir/c"
+            session(remotes.testServer) {
+                execute "mkdir -vp $remoteWorkDir"
+                put text: 1, into: "$remoteWorkDir/a"
+                put text: 2, into: "$remoteWorkDir/b"
+                put text: 3, into: "$remoteWorkDir/c"
 
-            eachFile(remoteWorkDir) {
-                println it.filename
+                eachFile(remoteWorkDir) {
+                    println it.filename
+                }
             }
         }
     }
@@ -32,23 +34,25 @@ dependencies {
     groovyRuntime 'org.codehaus.groovy:groovy-all:2.3.9'
 }
 
-task('should apply the extension which accesses to the project') << {
-    assert ssh.run {
-        settings {
-            extensions << [executeGroovyScript: { String script ->
-                def temporaryPath = "/tmp/${UUID.randomUUID()}"
-                try {
-                    execute "mkdir -vp $temporaryPath"
-                    put from: project.configurations.groovyRuntime, into: temporaryPath
-                    put text: script, into: "$temporaryPath/script.groovy"
-                    execute "java -jar $temporaryPath/groovy-all-*.jar $temporaryPath/script.groovy"
-                } finally {
-                    execute "rm -vfr $temporaryPath"
-                }
-            }]
-        }
-        session(remotes.testServer) {
-            executeGroovyScript 'println GroovySystem.version'
-        }
-    } == '2.3.9'
+task('should apply the extension which accesses to the project') {
+    doLast {
+        assert ssh.run {
+            settings {
+                extensions << [executeGroovyScript: { String script ->
+                    def temporaryPath = "/tmp/${UUID.randomUUID()}"
+                    try {
+                        execute "mkdir -vp $temporaryPath"
+                        put from: project.configurations.groovyRuntime, into: temporaryPath
+                        put text: script, into: "$temporaryPath/script.groovy"
+                        execute "java -jar $temporaryPath/groovy-all-*.jar $temporaryPath/script.groovy"
+                    } finally {
+                        execute "rm -vfr $temporaryPath"
+                    }
+                }]
+            }
+            session(remotes.testServer) {
+                executeGroovyScript 'println GroovySystem.version'
+            }
+        } == '2.3.9'
+    }
 }

--- a/acceptance-test/fixture/spec/FileTransferSpec.gradle
+++ b/acceptance-test/fixture/spec/FileTransferSpec.gradle
@@ -1,47 +1,51 @@
 ['sftp', 'scp'].each { method ->
-    task("should put files of fileTree via $method") << {
-        localWorkDir.mkdirs()
-        file("$localWorkDir/a.dat") << 1
-        file("$localWorkDir/b.txt") << 2
-        file("$localWorkDir/c.dat") << 3
+    task("should put files of fileTree via $method") {
+        doLast {
+            localWorkDir.mkdirs()
+            file("$localWorkDir/a.dat") << 1
+            file("$localWorkDir/b.txt") << 2
+            file("$localWorkDir/c.dat") << 3
 
-        ssh.run {
-            settings {
-                fileTransfer = method
-            }
-            session(remotes.testServer) {
-                execute "mkdir -vp $remoteWorkDir"
-                put from: fileTree(dir: localWorkDir, include: '*.dat'), into: remoteWorkDir
-                execute "test   -f $remoteWorkDir/a.dat"
-                execute "test ! -f $remoteWorkDir/b.txt"
-                execute "test   -f $remoteWorkDir/c.dat"
+            ssh.run {
+                settings {
+                    fileTransfer = method
+                }
+                session(remotes.testServer) {
+                    execute "mkdir -vp $remoteWorkDir"
+                    put from: fileTree(dir: localWorkDir, include: '*.dat'), into: remoteWorkDir
+                    execute "test   -f $remoteWorkDir/a.dat"
+                    execute "test ! -f $remoteWorkDir/b.txt"
+                    execute "test   -f $remoteWorkDir/c.dat"
+                }
             }
         }
     }
 
-    task("should get the large file and put it back via $method") << {
-        def fileSize = 1024 * 8
-        localWorkDir.mkdirs()
+    task("should get the large file and put it back via $method") {
+        doLast {
+            def fileSize = 1024 * 8
+            localWorkDir.mkdirs()
 
-        ssh.run {
-            settings {
-                fileTransfer = method
+            ssh.run {
+                settings {
+                    fileTransfer = method
+                }
+                session(remotes.testServer) {
+                    execute "mkdir -vp $remoteWorkDir"
+                    execute "dd if=/dev/zero of=$remoteWorkDir/result bs=1024 count=$fileSize"
+                    get from: "$remoteWorkDir/result", into: localWorkDir
+                }
             }
-            session(remotes.testServer) {
-                execute "mkdir -vp $remoteWorkDir"
-                execute "dd if=/dev/zero of=$remoteWorkDir/result bs=1024 count=$fileSize"
-                get from: "$remoteWorkDir/result", into: localWorkDir
-            }
-        }
-        assert file("$localWorkDir/result").size() == 1024 * fileSize
+            assert file("$localWorkDir/result").size() == 1024 * fileSize
 
-        ssh.run {
-            settings {
-                fileTransfer = method
-            }
-            session(remotes.testServer) {
-                put from: "$localWorkDir/result", into: "$remoteWorkDir/back"
-                assert execute("wc -c < $remoteWorkDir/back") as int == 1024 * fileSize
+            ssh.run {
+                settings {
+                    fileTransfer = method
+                }
+                session(remotes.testServer) {
+                    put from: "$localWorkDir/result", into: "$remoteWorkDir/back"
+                    assert execute("wc -c < $remoteWorkDir/back") as int == 1024 * fileSize
+                }
             }
         }
     }

--- a/acceptance-test/fixture/spec/RemoteSpec.gradle
+++ b/acceptance-test/fixture/spec/RemoteSpec.gradle
@@ -10,32 +10,38 @@ remotes {
 }
 
 
-task('should execute the command on multiple remotes specified by brace list') << {
-    def x = randomInt()
-    def y = randomInt()
-    assert ssh.run {
-        session([remotes.testServer, remotes.yetAnotherServer]) {
-            execute "expr $x + $y"
-        }
-    }.every { it as int == (x + y) }
+task('should execute the command on multiple remotes specified by brace list') {
+    doLast {
+        def x = randomInt()
+        def y = randomInt()
+        assert ssh.run {
+            session([remotes.testServer, remotes.yetAnotherServer]) {
+                execute "expr $x + $y"
+            }
+        }.every { it as int == (x + y) }
+    }
 }
 
-task('should execute the command on multiple remotes specified by arguments') << {
-    def x = randomInt()
-    def y = randomInt()
-    assert ssh.run {
-        session(remotes.testServer, remotes.yetAnotherServer) {
-            execute "expr $x + $y"
-        }
-    }.every { it as int == (x + y) }
+task('should execute the command on multiple remotes specified by arguments') {
+    doLast {
+        def x = randomInt()
+        def y = randomInt()
+        assert ssh.run {
+            session(remotes.testServer, remotes.yetAnotherServer) {
+                execute "expr $x + $y"
+            }
+        }.every { it as int == (x + y) }
+    }
 }
 
-task('should execute the command on multiple remotes specified by the role') << {
-    def x = randomInt()
-    def y = randomInt()
-    assert ssh.run {
-        session(remotes.role('testServers')) {
-            execute "expr $x + $y"
-        }
-    }.every { it as int == (x + y) }
+task('should execute the command on multiple remotes specified by the role') {
+    doLast {
+        def x = randomInt()
+        def y = randomInt()
+        assert ssh.run {
+            session(remotes.role('testServers')) {
+                execute "expr $x + $y"
+            }
+        }.every { it as int == (x + y) }
+    }
 }

--- a/acceptance-test/fixture/spec/ScriptSpec.gradle
+++ b/acceptance-test/fixture/spec/ScriptSpec.gradle
@@ -1,21 +1,23 @@
 
-task('should execute the script') << {
-    def x = randomInt()
-    def y = randomInt()
+task('should execute the script') {
     def a
     def b
-    ssh.run {
-        session(remotes.testServer) {
-            executeScript """\
-            #!/bin/bash -xe
-            mkdir -vp $remoteWorkDir
-            expr $x + $y > $remoteWorkDir/A
-            expr $x + `cat $remoteWorkDir/A` > $remoteWorkDir/B
-            """.stripIndent()
-            a = get from: "$remoteWorkDir/A"
-            b = get from: "$remoteWorkDir/B"
+    doLast {
+        def x = randomInt()
+        def y = randomInt()
+        ssh.run {
+            session(remotes.testServer) {
+                executeScript """\
+                #!/bin/bash -xe
+                mkdir -vp $remoteWorkDir
+                expr $x + $y > $remoteWorkDir/A
+                expr $x + `cat $remoteWorkDir/A` > $remoteWorkDir/B
+                """.stripIndent()
+                a = get from: "$remoteWorkDir/A"
+                b = get from: "$remoteWorkDir/B"
+            }
         }
+        assert a as int == (x + y)
+        assert b as int == (x + x + y)
     }
-    assert a as int == (x + y)
-    assert b as int == (x + x + y)
 }

--- a/acceptance-test/fixture/spec/ShellSpec.gradle
+++ b/acceptance-test/fixture/spec/ShellSpec.gradle
@@ -1,50 +1,56 @@
 
-task('should execute the shell') << {
-    ssh.run {
-        session(remotes.testServer) {
-            shell(interaction: {
-                when(partial: ~/.*[$%#]\W*/, from: standardOutput) {
-                    standardInput << 'uname -a' << '\n'
-
-                    when(partial: ~/.*[$%#]\W*/, from: standardOutput) {
-                        standardInput << 'exit 0' << '\n'
-                    }
-                    when(line: _, from: standardOutput) {}
-                }
-                when(line: _, from: standardOutput) {}
-            })
-        }
-    }
-}
-
-task('should write output of the shell to the file') << {
-    def x = randomInt()
-    def y = randomInt()
-    localWorkDir.mkdirs()
-    def resultFile = file("$localWorkDir/result")
-    resultFile.withOutputStream { stream ->
+task('should execute the shell') {
+    doLast {
         ssh.run {
             session(remotes.testServer) {
-                execute "expr $x + $y", outputStream: stream
+                shell(interaction: {
+                    when(partial: ~/.*[$%#]\W*/, from: standardOutput) {
+                        standardInput << 'uname -a' << '\n'
+
+                        when(partial: ~/.*[$%#]\W*/, from: standardOutput) {
+                            standardInput << 'exit 0' << '\n'
+                        }
+                        when(line: _, from: standardOutput) {}
+                    }
+                    when(line: _, from: standardOutput) {}
+                })
             }
         }
     }
-    assert resultFile.text as int == (x + y)
 }
 
-task('should write output of the shell to the standard output') << {
-    ssh.run {
-        session(remotes.testServer) {
-            shell outputStream: System.out, interaction: {
-                when(partial: ~/.*[$%#]\W*/, from: standardOutput) {
-                    standardInput << 'uname -a' << '\n'
+task('should write output of the shell to the file') {
+    doLast {
+        def x = randomInt()
+        def y = randomInt()
+        localWorkDir.mkdirs()
+        def resultFile = file("$localWorkDir/result")
+        resultFile.withOutputStream { stream ->
+            ssh.run {
+                session(remotes.testServer) {
+                    execute "expr $x + $y", outputStream: stream
+                }
+            }
+        }
+        assert resultFile.text as int == (x + y)
+    }
+}
 
+task('should write output of the shell to the standard output') {
+    doLast {
+        ssh.run {
+            session(remotes.testServer) {
+                shell outputStream: System.out, interaction: {
                     when(partial: ~/.*[$%#]\W*/, from: standardOutput) {
-                        standardInput << 'exit 0' << '\n'
+                        standardInput << 'uname -a' << '\n'
+
+                        when(partial: ~/.*[$%#]\W*/, from: standardOutput) {
+                            standardInput << 'exit 0' << '\n'
+                        }
+                        when(line: _, from: standardOutput) {}
                     }
                     when(line: _, from: standardOutput) {}
                 }
-                when(line: _, from: standardOutput) {}
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -16,10 +16,12 @@ allprojects {
     }
 }
 
-task resolveDependencies << {
-    allprojects.each { project ->
-        project.buildscript.configurations*.resolve()
-        project.configurations*.resolve()
+task resolveDependencies {
+    doLast {
+        allprojects.each { project ->
+            project.buildscript.configurations*.resolve()
+            project.configurations*.resolve()
+        }
     }
 }
 

--- a/core/src/test/groovy/org/hidetake/gradle/ssh/plugin/DryRunSpec.groovy
+++ b/core/src/test/groovy/org/hidetake/gradle/ssh/plugin/DryRunSpec.groovy
@@ -28,10 +28,12 @@ class DryRunSpec extends Specification {
     def "dry-run shell should work without server"() {
         given:
         project.with {
-            task('testTask') << {
-                ssh.run {
-                    session(remotes.testServer) {
-                        shell(interaction: {})
+            task('testTask') {
+                doLast {
+                    ssh.run {
+                        session(remotes.testServer) {
+                            shell(interaction: {})
+                        }
                     }
                 }
             }
@@ -47,10 +49,12 @@ class DryRunSpec extends Specification {
     def "dry-run shell with options should work without server"() {
         given:
         project.with {
-            task('testTask') << {
-                ssh.run {
-                    session(project.remotes.testServer) {
-                        shell(logging: 'none')
+            task('testTask') {
+                doLast {
+                    ssh.run {
+                        session(project.remotes.testServer) {
+                            shell(logging: 'none')
+                        }
                     }
                 }
             }
@@ -66,10 +70,12 @@ class DryRunSpec extends Specification {
     def "dry-run command should work without server"() {
         given:
         project.with {
-            task('testTask') << {
-                ssh.run {
-                    session(project.remotes.testServer) {
-                        execute('ls -l')
+            task('testTask') {
+                doLast {
+                    ssh.run {
+                        session(project.remotes.testServer) {
+                            execute('ls -l')
+                        }
                     }
                 }
             }
@@ -85,11 +91,13 @@ class DryRunSpec extends Specification {
     def "dry-run command with callback should work without server"() {
         given:
         project.with {
-            task('testTask') << {
-                ssh.run {
-                    session(project.remotes.testServer) {
-                        execute('ls -l') {
-                            project.ext.callbackExecuted = true
+            task('testTask') {
+                doLast {
+                    ssh.run {
+                        session(project.remotes.testServer) {
+                            execute('ls -l') {
+                                project.ext.callbackExecuted = true
+                            }
                         }
                     }
                 }
@@ -107,10 +115,12 @@ class DryRunSpec extends Specification {
     def "dry-run command with options should work without server"() {
         given:
         project.with {
-            task('testTask') << {
-                ssh.run {
-                    session(project.remotes.testServer) {
-                        execute('ls -l', pty: true)
+            task('testTask') {
+                doLast {
+                    ssh.run {
+                        session(project.remotes.testServer) {
+                            execute('ls -l', pty: true)
+                        }
                     }
                 }
             }
@@ -126,11 +136,13 @@ class DryRunSpec extends Specification {
     def "dry-run command with options and callback should work without server"() {
         given:
         project.with {
-            task('testTask') << {
-                ssh.run {
-                    session(project.remotes.testServer) {
-                        execute('ls -l', pty: true) {
-                            project.ext.callbackExecuted = true
+            task('testTask') {
+                doLast {
+                    ssh.run {
+                        session(project.remotes.testServer) {
+                            execute('ls -l', pty: true) {
+                                project.ext.callbackExecuted = true
+                            }
                         }
                     }
                 }
@@ -148,10 +160,12 @@ class DryRunSpec extends Specification {
     def "dry-run command in background should work without server"() {
         given:
         project.with {
-            task('testTask') << {
-                ssh.run {
-                    session(project.remotes.testServer) {
-                        executeBackground('ls -l')
+            task('testTask') {
+                doLast {
+                    ssh.run {
+                        session(project.remotes.testServer) {
+                            executeBackground('ls -l')
+                        }
                     }
                 }
             }
@@ -167,11 +181,13 @@ class DryRunSpec extends Specification {
     def "dry-run command in background with callback should work without server"() {
         given:
         project.with {
-            task('testTask') << {
-                ssh.run {
-                    session(project.remotes.testServer) {
-                        executeBackground('ls -l') {
-                            project.ext.callbackExecuted = true
+            task('testTask') {
+                doLast {
+                    ssh.run {
+                        session(project.remotes.testServer) {
+                            executeBackground('ls -l') {
+                                project.ext.callbackExecuted = true
+                            }
                         }
                     }
                 }
@@ -189,10 +205,12 @@ class DryRunSpec extends Specification {
     def "dry-run command with options in background should work without server"() {
         given:
         project.with {
-            task('testTask') << {
-                ssh.run {
-                    session(project.remotes.testServer) {
-                        executeBackground('ls -l', pty: true)
+            task('testTask') {
+                doLast {
+                    ssh.run {
+                        session(project.remotes.testServer) {
+                            executeBackground('ls -l', pty: true)
+                        }
                     }
                 }
             }
@@ -208,11 +226,13 @@ class DryRunSpec extends Specification {
     def "dry-run command with options and callback in background should work without server"() {
         given:
         project.with {
-            task('testTask') << {
-                ssh.run {
-                    session(project.remotes.testServer) {
-                        executeBackground('ls -l', pty: true) {
-                            project.ext.callbackExecuted = true
+            task('testTask') {
+                doLast {
+                    ssh.run {
+                        session(project.remotes.testServer) {
+                            executeBackground('ls -l', pty: true) {
+                                project.ext.callbackExecuted = true
+                            }
                         }
                     }
                 }

--- a/core/src/test/groovy/org/hidetake/gradle/ssh/plugin/ExtensionSpec.groovy
+++ b/core/src/test/groovy/org/hidetake/gradle/ssh/plugin/ExtensionSpec.groovy
@@ -28,10 +28,12 @@ class ExtensionSpec extends Specification {
     def "extension should be able to access to the project"() {
         given:
         project.with {
-            task('testTask') << {
-                project.ext.result = ssh.run {
-                    session(remotes.testServer) {
-                        example()
+            task('testTask') {
+                doLast {
+                    project.ext.result = ssh.run {
+                        session(remotes.testServer) {
+                            example()
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This fixes the deprecation warning described in #282.

### Steps to verify the fix
1. install the new version
2. use ssh.run{} in your gradle scripts
3. run your gradle script without warning