### PR TITLE
Fix typo in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ e.g.
 ./acceptance-test/setup-ssh.sh
 
 # Run test
-./gradlew -Ptarget.gradle.versions=3.0,2.0,1.12 :acceptance-tests:test
+./gradlew -Ptarget.gradle.versions=3.0,2.0,1.12 :acceptance-test:test
 ```
 
 ### Release


### PR DESCRIPTION
Correct the `Run test` command.

### Steps to use the feature | verify the fix
1. Try to run the old command: `./gradlew -Ptarget.gradle.versions=3.0,2.0,1.12 :acceptance-tests:test`
2. Try to run the corrected command: `./gradlew -Ptarget.gradle.versions=3.0,2.0,1.12 :acceptance-test:test`
