### PR TITLE
Groovy SSH 2.8.0

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -10,7 +10,7 @@ targetCompatibility = JavaVersion.VERSION_1_6
 dependencies {
     compile gradleApi()
     compile localGroovy()
-    compile('org.hidetake:groovy-ssh:2.7.2') {
+    compile('org.hidetake:groovy-ssh:2.8.0') {
         exclude module: 'groovy-all'
     }
     testCompile('org.spockframework:spock-core:1.0-groovy-2.4') {


### PR DESCRIPTION
https://github.com/int128/groovy-ssh/releases/tag/2.8.0